### PR TITLE
Switch back to ext4 because Concourse is now using overlayfs.

### DIFF
--- a/ec2-worker/asg.tf
+++ b/ec2-worker/asg.tf
@@ -116,7 +116,7 @@ EOF
     content = <<EOF
 fs_setup:
   - label: concourseworkdir
-    filesystem: 'btrfs'
+    filesystem: 'ext4'
     device: '${var.work_disk_device_name}'
 EOF
   }
@@ -127,7 +127,7 @@ EOF
 
     content = <<EOF
 mounts:
-  - [ ${var.work_disk_device_name}, /opt/concourse, btrfs, "defaults", "0", "2" ]
+  - [ ${var.work_disk_device_name}, /opt/concourse, ext4, "defaults", "0", "2" ]
 EOF
   }
 


### PR DESCRIPTION
To support nested volumes, Concourse required the use of the `btrfs` file system. But this wasn't really speedy.

Concourse 3.1.0 introduced the use of the `overlay` file system on top of a regular file system like `ext4` for nested volumes. Performance measurements by the concourse team have shown a considerable improvement.

Switch our setup to have EC2 workers with an `ext4` file system attached.