### PR TITLE
adding constraint to run a concourse-web container per ec2 instance

### DIFF
--- a/ecs-web/web.tf
+++ b/ecs-web/web.tf
@@ -10,6 +10,11 @@ resource "aws_ecs_service" "concourse_web" {
     container_name = "concourse_web"
     container_port = 8080
   }
+
+  placement_strategy {
+    type  = "spread"
+    field = "instanceId"
+  }
 }
 
 resource "aws_ecs_task_definition" "concourse_web_task_definition" {


### PR DESCRIPTION
This will ensure that you cannot run two docker containers on the same instance.
NBL only supports TCP and not TLS. I'd stay with the elb for the moment. If in the future the nlb/alb will improve we can re-consider it.

https://github.com/skyscrapers/ci/issues/22

Any feedback is more than welcome