### PR TITLE
adding option to specify cpu and memory for container

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The following resources are created:
  * [`keys_bucket_arn`]: String(required): The ARN of the bucket where the concourse keys. Used to allow access to the bucket.
  * [`vault_server_url`]: String(optional): The Vault server URL to configure in Concourse. Leaving it empty will disable the Vault integration. Defaults to ""
  * [`vault_auth_concourse_role_name`]: String(optional): The Vault role that Concourse will use. This is normally fetched from the `vault-auth` terraform module. Defaults to "".
+ * [`container_cpu`]: Int(optional): The number of cpu units to reserve for the container. This parameter maps to CpuShares in the Create a container section of the Docker Remote API. Defaults to 256.
+ * [`container_memory`]: Int(optional): The amount of memory (in MiB) used by the task. Defaults to 256.
 
 Depending on if you want standard Github authentication or standard authentication,
 you need to fill in the following variables. We advise to use Github as there you can enforce 2 factor
@@ -180,7 +182,7 @@ The following resources will be created:
 | work_disk_device_name | Device name of the external EBS volume | `/dev/xvdf` | no |
 | work_disk_volume_size | Size of the external EBS volume | `100` | no |
 | work_disk_volume_type | Volume type of the external EBS volume | `standard` | no |
-| concourse_tag | Tag to add to the worker to use for assigning jobs and tasks | - | no | 
+| concourse_tag | Tag to add to the worker to use for assigning jobs and tasks | - | no |
 | tsa_account_id | AWS Account ID of the TSA when remote | - | no |
 
 ### Output

--- a/ecs-web/task-definitions/concourse_web_service.json
+++ b/ecs-web/task-definitions/concourse_web_service.json
@@ -3,8 +3,8 @@
     "name": "concourse_web",
     "image": "${image}",
     "command": [ "web" ],
-    "cpu": 10,
-    "memory": 256,
+    "cpu": ${cpu},
+    "memory": ${memory},
     "essential": true,
     "portMappings": [
       {

--- a/ecs-web/variables.tf
+++ b/ecs-web/variables.tf
@@ -115,3 +115,11 @@ variable "vault_auth_concourse_role_name" {
   description = "The Vault role that Concourse will use. This is normally fetched from the `vault-auth` terraform module."
   default     = ""
 }
+
+variable "container_memory" {
+  default = 256
+}
+
+variable "container_cpu" {
+  default = 256
+}

--- a/ecs-web/web.tf
+++ b/ecs-web/web.tf
@@ -37,6 +37,8 @@ data "template_file" "concourse_web_task_template" {
     concourse_basic_auth       = "${length(var.concourse_auth_username) > 0 && length(var.concourse_auth_password) > 0 ? data.template_file.concourse_basic_auth.rendered : ""}"
     concourse_github_auth      = "${length(var.concourse_github_auth_client_id) > 0 && length(var.concourse_github_auth_client_secret) > 0 && length(var.concourse_github_auth_team) > 0 ? data.template_file.concourse_github_auth.rendered : ""}"
     concourse_vault_variables  = "${length(var.vault_server_url) > 0 ? data.template_file.concourse_vault_variables.rendered : ""}"
+    memory                     = "${var.container_memory}"
+    cpu                        = "${var.container_cpu}"
   }
 }
 


### PR DESCRIPTION
The CPUUtilization is currently way out of it's reservation. Luckily the ECS cluster has spare capacity so the ECS scheduler allows the concourse web container to use more CPU.

I've added the option to customize those parameters
https://github.com/skyscrapers/ci/issues/35