### PR TITLE
Fix edge-case where CONCOURSE_TAG is empty on EC2 workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The following resources will be created:
 | work_disk_internal_device_name | Device name of the internal EBS volume | `/dev/xvdf` | no |
 | work_disk_volume_size | Size of the external EBS volume | `100` | no |
 | work_disk_volume_type | Volume type of the external EBS volume | `standard` | no |
-| concourse_tag | Tag to add to the worker to use for assigning jobs and tasks | - | no |
+| concourse_tags | List of tags to add to the worker to use for assigning jobs and tasks | [ ] | no |
 | tsa_account_id | AWS Account ID of the TSA when remote | - | no |
 
 ### Output

--- a/ec2-worker/asg.tf
+++ b/ec2-worker/asg.tf
@@ -74,7 +74,7 @@ data "template_file" "concourse_systemd" {
 
   vars {
     concourse_hostname = "${var.concourse_hostname}"
-    concourse_tag      = "${var.concourse_tag}"
+    tags               = "${join(" ", formatlist("--tag=%s", var.concourse_tags))}"
   }
 }
 
@@ -122,7 +122,7 @@ EOF
 aws --region $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//') ec2 wait volume-in-use --filters Name=attachment.instance-id,Values=$(curl -s http://169.254.169.254/latest/meta-data/instance-id) Name=attachment.device,Values=${var.work_disk_device_name}
 EOF
   }
-  
+
   # Format external volume as btrfs
   part {
     content_type = "text/cloud-config"

--- a/ec2-worker/concourse_systemd.tpl
+++ b/ec2-worker/concourse_systemd.tpl
@@ -2,12 +2,11 @@
 Description=Concourse CI Worker
 
 [Service]
-Environment=CONCOURSE_TAG=${concourse_tag}
 ExecStart=/usr/local/bin/concourse worker \
        --work-dir /opt/concourse \
        --tsa-host ${concourse_hostname} \
        --tsa-public-key /etc/concourse/tsa_host_key.pub \
-       --tsa-worker-private-key /etc/concourse/worker_key
+       --tsa-worker-private-key /etc/concourse/worker_key ${tags}
 
 User=root
 Group=root

--- a/ec2-worker/variables.tf
+++ b/ec2-worker/variables.tf
@@ -86,9 +86,10 @@ variable "keys_bucket_arn" {
   description = "The S3 bucket ARN which contains the SSH keys to connect to the TSA"
 }
 
-variable "concourse_tag" {
-  description = "Tag to add to the worker to use for assigning jobs and tasks"
-  default     = ""
+variable "concourse_tags" {
+  description = "List of tags to add to the worker to use for assigning jobs and tasks"
+  type        = "list"
+  default     = []
 }
 
 variable "tsa_account_id" {


### PR DESCRIPTION
We added the environment variable CONCOURSE_TAG on EC2 workers to register those workers to only fetch jobs with those tags. The problem comes when we don't need to specify any tag, then that variable is set to empty, and somehow the ATC doesn't assign any job to that worker because of that.

With this change, the worker tags are set as command line flags, and multiple of them can be specified in a list.