### PR TITLE
switch concourse workers back to btrfs starting from v3.9.0

### DIFF
--- a/ec2-worker/asg.tf
+++ b/ec2-worker/asg.tf
@@ -130,7 +130,7 @@ EOF
     content = <<EOF
 fs_setup:
   - label: concourseworkdir
-    filesystem: 'ext4'
+    filesystem: 'btrfs'
     device: '${var.work_disk_internal_device_name}'
 EOF
   }
@@ -141,7 +141,7 @@ EOF
 
     content = <<EOF
 mounts:
-  - [ ${var.work_disk_internal_device_name}, /opt/concourse, ext4, "defaults", "0", "2" ]
+  - [ ${var.work_disk_internal_device_name}, /opt/concourse, btrfs, "defaults", "0", "2" ]
 EOF
   }
 


### PR DESCRIPTION
with the release of (v3.9.0)[https://concourse-ci.org/downloads.html#v390] the implementation of the btrfs has improved a lot cfr issue [#1966](https://github.com/concourse/concourse/issues/1966).

Therefore we switch the worker fs to btrfs starting from now to have better worker performance.
This will be a breaking release with the older versions of concourse so i will make the new release 7.0.0