### PR TITLE
Make concourse_workers_iam_role_arns variable mandatory in keys module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following resources are created:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | aws_profile | This is the AWS profile name as set in the shared credentials file. Used to upload the Concourse keys to S3. Omit this if you're using environment variables. | string | `` | no |
-| concourse_keys_cross_account_principals | AWS Principals that can assume the role to access the concourse keys. Intended to setup Concourse workers on other AWS accounts | list | `<list>` | no |
+| concourse_workers_iam_role_arns | List of ARNs for the IAM roles that will be able to assume the role to access concourse keys in S3. Normally you'll include the Concourse worker IAM role here | list | - | yes |
 | concourse_keys_version | Change this if you want to re-generate Concourse keys | string | `1` | no |
 | environment | The name of the environment these subnets belong to (prod,stag,dev) | string | - | yes |
 | name | The name of the Concourse deployment, used to distinguish different Concourse setups | string | - | yes |
@@ -163,7 +163,8 @@ The following resources will be created:
 | Name | Description |
 |------|-------------|
 | worker_instances_sg_id | Security group ID used for the worker instances |
-| worker_iam_role | Role name of the worker instance |
+| worker_iam_role | Role name of the worker instances |
+| worker_iam_role_arn | Role ARN of the worker instances |
 
 ### Example
 ```

--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ The following resources are created:
 ### Example
 ```
 module "concourse-keys" {
-  source      = "github.com/skyscrapers/terraform-concourse//keys"
-  environment = "${terraform.env}"
-  name        = "internal"
+  source                          = "github.com/skyscrapers/terraform-concourse//keys"
+  environment                     = "${terraform.env}"
+  name                            = "internal"
+  concourse_workers_iam_role_arns = ["${module.concourse-worker.worker_iam_role_arn}"]
 }
 ```
 

--- a/ec2-worker/outputs.tf
+++ b/ec2-worker/outputs.tf
@@ -5,3 +5,7 @@ output "worker_instances_sg_id" {
 output "worker_iam_role" {
   value = "${aws_iam_role.concourse_worker_role.name}"
 }
+
+output "worker_iam_role_arn" {
+  value = "${aws_iam_role.concourse_worker_role.arn}"
+}

--- a/keys/cross-account.tf
+++ b/keys/cross-account.tf
@@ -5,7 +5,7 @@ data "aws_iam_policy_document" "concourse_keys_cross_account_assume_role_policy"
 
     principals {
       type        = "AWS"
-      identifiers = "${var.concourse_keys_cross_account_principals}"
+      identifiers = ["${var.concourse_workers_iam_role_arns}"]
     }
   }
 }

--- a/keys/outputs.tf
+++ b/keys/outputs.tf
@@ -9,6 +9,6 @@ output "keys_bucket_arn" {
 }
 
 output "concourse_keys_cross_account_role_arn" {
-  value       = "${join("", aws_iam_role.concourse_keys_cross_account.*.arn)}"
+  value       = "${aws_iam_role.concourse_keys_cross_account.arn}"
   description = "IAM role ARN that Concourse workers on other AWS accounts will need to assume to access the Concourse keys bucket"
 }

--- a/keys/variables.tf
+++ b/keys/variables.tf
@@ -16,8 +16,7 @@ variable "concourse_keys_version" {
   default     = "1"
 }
 
-variable "concourse_keys_cross_account_principals" {
+variable "concourse_workers_iam_role_arns" {
   type        = "list"
-  default     = []
-  description = "AWS Principals that can assume the role to access the concourse keys. Intended to setup Concourse workers on other AWS accounts"
+  description = "List of ARNs for the IAM roles that will be able to assume the role to access concourse keys in S3. Normally you'll include the Concourse worker IAM role here"
 }


### PR DESCRIPTION
By always providing a worker iam role in `concourse_workers_iam_role_arns` in the keys module. Concourse workers will be able to access the keys bucket via assuming the role created for that purpose. It'll also allow access in cross-account worker deployments.

Fixes #25