### PR TITLE
adding max-ttl to vault token

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ The following resources are created:
  * [`keys_bucket_id`]: String(required): The id (name) of the bucket where the concourse keys are stored.
  * [`keys_bucket_arn`]: String(required): The ARN of the bucket where the concourse keys. Used to allow access to the bucket.
  * [`vault_server_url`]: String(optional): The Vault server URL to configure in Concourse. Leaving it empty will disable the Vault integration. Defaults to ""
- * [`vault_auth_concourse_role_name`]: String(optional): The Vault role that Concourse will use. This is normally fetched from the `vault-auth` terraform module. Defaults to "2592000" (30 days).
- * [`concourse_vault_auth_backend_max_ttl`]: String(optional): The Vault max-ttl that Concourse will use. Defaults to "".
+ * [`vault_auth_concourse_role_name`]: String(optional): The Vault role that Concourse will use. This is normally fetched from the `vault-auth` terraform module. Defaults to "".
+ * [`concourse_vault_auth_backend_max_ttl`]: String(optional): The Vault max-ttl that Concourse will use. Defaults to "2592000" (30 days).
  * [`container_cpu`]: Int(optional): The number of cpu units to reserve for the container. This parameter maps to CpuShares in the Create a container section of the Docker Remote API. Defaults to 256.
  * [`container_memory`]: Int(optional): The amount of memory (in MiB) used by the task. Defaults to 256.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ The following resources are created:
  * [`keys_bucket_id`]: String(required): The id (name) of the bucket where the concourse keys are stored.
  * [`keys_bucket_arn`]: String(required): The ARN of the bucket where the concourse keys. Used to allow access to the bucket.
  * [`vault_server_url`]: String(optional): The Vault server URL to configure in Concourse. Leaving it empty will disable the Vault integration. Defaults to ""
- * [`vault_auth_concourse_role_name`]: String(optional): The Vault role that Concourse will use. This is normally fetched from the `vault-auth` terraform module. Defaults to "".
+ * [`vault_auth_concourse_role_name`]: String(optional): The Vault role that Concourse will use. This is normally fetched from the `vault-auth` terraform module. Defaults to "2592000" (30 days).
+ * [`concourse_vault_auth_backend_max_ttl`]: String(optional): The Vault max-ttl that Concourse will use. Defaults to "".
  * [`container_cpu`]: Int(optional): The number of cpu units to reserve for the container. This parameter maps to CpuShares in the Create a container section of the Docker Remote API. Defaults to 256.
  * [`container_memory`]: Int(optional): The amount of memory (in MiB) used by the task. Defaults to 256.
 

--- a/ecs-web/main.tf
+++ b/ecs-web/main.tf
@@ -50,12 +50,14 @@ data "template_file" "concourse_vault_variables" {
 { "name": "CONCOURSE_VAULT_URL", "value": "$${concourse_vault_url}" },
 { "name": "CONCOURSE_VAULT_AUTH_BACKEND", "value": "$${concourse_vault_auth_backend}" },
 { "name": "CONCOURSE_VAULT_AUTH_PARAM", "value": "$${concourse_vault_auth_param}" },
+{ "name": "CONCOURSE_VAULT_AUTH_BACKEND_MAX_TTL", "value": "$${concourse_vault_auth_backend_max_ttl}" },
 EOF
 
   vars {
     concourse_vault_url          = "${var.vault_server_url}"
     concourse_vault_auth_backend = "aws"
     concourse_vault_auth_param   = "header_value=${replace(replace(var.vault_server_url, "/^http(s)?:///", ""), "/", "")},role=${var.vault_auth_concourse_role_name}"
+    concourse_vault_auth_backend_max_ttl          = "${var.concourse_vault_auth_backend_max_ttl}"
   }
 }
 

--- a/ecs-web/main.tf
+++ b/ecs-web/main.tf
@@ -1,5 +1,4 @@
-data "aws_region" "current" {
-}
+data "aws_region" "current" {}
 
 resource "aws_ecs_service" "concourse_web" {
   name            = "concourse_web_${var.name}_${var.environment}"
@@ -54,10 +53,10 @@ data "template_file" "concourse_vault_variables" {
 EOF
 
   vars {
-    concourse_vault_url          = "${var.vault_server_url}"
-    concourse_vault_auth_backend = "aws"
-    concourse_vault_auth_param   = "header_value=${replace(replace(var.vault_server_url, "/^http(s)?:///", ""), "/", "")},role=${var.vault_auth_concourse_role_name}"
-    concourse_vault_auth_backend_max_ttl          = "${var.concourse_vault_auth_backend_max_ttl}"
+    concourse_vault_url                  = "${var.vault_server_url}"
+    concourse_vault_auth_backend         = "aws"
+    concourse_vault_auth_param           = "header_value=${replace(replace(var.vault_server_url, "/^http(s)?:///", ""), "/", "")},role=${var.vault_auth_concourse_role_name}"
+    concourse_vault_auth_backend_max_ttl = "${var.concourse_vault_auth_backend_max_ttl}"
   }
 }
 

--- a/ecs-web/variables.tf
+++ b/ecs-web/variables.tf
@@ -118,6 +118,9 @@ variable "vault_auth_concourse_role_name" {
   default     = ""
 }
 
+variable "concourse_vault_auth_backend_max_ttl" {
+  default = "2592000"
+}
 variable "container_memory" {
   default = 256
 }

--- a/ecs-web/variables.tf
+++ b/ecs-web/variables.tf
@@ -35,7 +35,7 @@ variable "concourse_db_port" {
 
 variable "concourse_db_username" {
   description = "db user to logon to postgresql"
-  default = "concourse"
+  default     = "concourse"
 }
 
 variable "concourse_db_password" {
@@ -44,7 +44,7 @@ variable "concourse_db_password" {
 
 variable "concourse_db_name" {
   description = "db name to use on the postgresql server"
-  default = "concourse"
+  default     = "concourse"
 }
 
 variable "ecs_service_role_arn" {
@@ -121,6 +121,7 @@ variable "vault_auth_concourse_role_name" {
 variable "concourse_vault_auth_backend_max_ttl" {
   default = "2592000"
 }
+
 variable "container_memory" {
   default = 256
 }


### PR DESCRIPTION
 Auth backend max TTL. Concourse will renew its token and then re-login when the auth backend max TTL is reached. 