### PR TITLE
adding configuration for teleport in workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The following resources will be created:
 | work_disk_volume_size | Size of the external EBS volume | string | `100` | no |
 | work_disk_volume_type | Volume type of the external EBS volume | string | `standard` | no |
 | worker_tsa_port | tsa port that the worker can use to connect to the web | string | `2222` | no |
-| teleport_auth_token_encrypted | Teleport server node token encrypted with context teleport=tokens | string | `` | no |
+| teleport_auth_token | Teleport server node token  | string | `` | no |
 | teleport_version | teleport version for the client | string | `2.5.8` | no |
 | teleport_sg | Teleport server security group id | string | `` | no |
 

--- a/README.md
+++ b/README.md
@@ -149,19 +149,20 @@ The following resources will be created:
 | keys_bucket_arn | The S3 bucket ARN which contains the SSH keys to connect to the TSA | string | - | yes |
 | keys_bucket_id | The S3 bucket id which contains the SSH keys to connect to the TSA | string | - | yes |
 | name | A descriptive name of the purpose of this Concourse worker pool | string | - | yes |
+| project | Project where the concourse claster belongs to. This is mainly used to identify it in teleport | string | `` | no |
 | root_disk_volume_size | Size of the worker instances root disk | string | `10` | no |
 | root_disk_volume_type | Volume type of the worker instances root disk | string | `standard` | no |
 | ssh_key_name | The key name to use for the instance | string | - | yes |
 | subnet_ids | List of subnet ids where to deploy the worker instances | list | - | yes |
+| teleport_auth_token | Teleport server node token  | string | `` | no |
+| teleport_sg | Teleport server security group id | string | `` | no |
+| teleport_version | teleport version for the client | string | `2.5.8` | no |
 | vpc_id | The VPC id where to deploy the worker instances | string | - | yes |
 | work_disk_device_name | Device name of the external EBS volume | string | `/dev/xvdf` | no |
 | work_disk_internal_device_name | Device name of the internal volume | string | `/dev/xvdf` | no |
 | work_disk_volume_size | Size of the external EBS volume | string | `100` | no |
 | work_disk_volume_type | Volume type of the external EBS volume | string | `standard` | no |
 | worker_tsa_port | tsa port that the worker can use to connect to the web | string | `2222` | no |
-| teleport_auth_token | Teleport server node token  | string | `` | no |
-| teleport_version | teleport version for the client | string | `2.5.8` | no |
-| teleport_sg | Teleport server security group id | string | `` | no |
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ The following resources will be created:
 | work_disk_volume_size | Size of the external EBS volume | string | `100` | no |
 | work_disk_volume_type | Volume type of the external EBS volume | string | `standard` | no |
 | worker_tsa_port | tsa port that the worker can use to connect to the web | string | `2222` | no |
+| teleport_auth_token_encrypted | Teleport server node token encrypted with context teleport=tokens | string | `` | no |
+| teleport_version | teleport version for the client | string | `2.5.8` | no |
+| teleport_sg | Teleport server security group id | string | `` | no |
 
 ### Output
 

--- a/ec2-worker/asg.tf
+++ b/ec2-worker/asg.tf
@@ -175,6 +175,7 @@ EOF
 
   part {
     content_type = "text/x-shellscript"
+
     content = <<EOF
 #!/bin/bash
 cd /tmp
@@ -197,4 +198,5 @@ module "teleport_bootstrap_script" {
   auth_token  = "${var.teleport_auth_token}"
   function    = "concourse"
   environment = "${var.environment}"
+  project     = "${var.project}"
 }

--- a/ec2-worker/asg.tf
+++ b/ec2-worker/asg.tf
@@ -198,16 +198,3 @@ module "teleport_bootstrap_script" {
   function    = "concourse"
   environment = "${var.environment}"
 }
-
-output "test"{
-  value =<<EOF
-write_files:
-- encoding: b64
-  content: ${base64encode(data.template_file.concourse_systemd.rendered)}
-  owner: root:root
-  path: /etc/systemd/system/concourse_worker.service
-  permissions: '0755'
-${module.teleport_bootstrap_script.teleport_config_cloudinit}
-${module.teleport_bootstrap_script.teleport_service_cloudinit}
-EOF
-}

--- a/ec2-worker/variables.tf
+++ b/ec2-worker/variables.tf
@@ -6,6 +6,11 @@ variable "name" {
   description = "A descriptive name of the purpose of this Concourse worker pool"
 }
 
+variable "project" {
+  description = "Project where the concourse claster belongs to. This is mainly used to identify it in teleport ''"
+  default     = ""
+}
+
 variable "vpc_id" {
   description = "The VPC id where to deploy the worker instances"
 }
@@ -104,6 +109,7 @@ variable "cross_account_worker_role_arn" {
 variable "teleport_server" {
   default = ""
 }
+
 variable "teleport_auth_token" {
   default = ""
 }

--- a/ec2-worker/variables.tf
+++ b/ec2-worker/variables.tf
@@ -100,3 +100,14 @@ variable "cross_account_worker_role_arn" {
   description = "IAM role ARN to assume to access the Concourse keys bucket in another AWS account"
   default     = ""
 }
+
+variable "teleport_server" {
+  default = ""
+}
+variable "teleport_auth_token" {
+  default = ""
+}
+
+variable "teleport_version" {
+  default = "2.5.8"
+}


### PR DESCRIPTION
This PR allows to specify the teleport to configuration in order to connect to a teleport server keeping the option to not set a teleport server and keep working fine. 
we'd like to enforce going forward teleport on all our concourse worker nodes but this will make the transition easier.

It has been tested in Qover (that already has concourse workers accessible via teleport)