### PR TITLE
Exposing Concourse Metrics for Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The following resources are created:
  * [`concourse_vault_auth_backend_max_ttl`]: String(optional): The Vault max-ttl that Concourse will use. Defaults to "2592000" (30 days).
  * [`container_cpu`]: Int(optional): The number of cpu units to reserve for the container. This parameter maps to CpuShares in the Create a container section of the Docker Remote API. Defaults to 256.
  * [`container_memory`]: Int(optional): The amount of memory (in MiB) used by the task. Defaults to 256.
+ * [`concourse_prometheus_bind_ip`]: String(optional) default 0.0.0.0: IP to listen on to expose Prometheus metrics
+ * [`concourse_prometheus_bind_port`]: String(optional) default 9391: Port to listen on to expose Prometheus metrics
 
 Depending on if you want standard Github authentication or standard authentication,
 you need to fill in the following variables. We advise to use Github as there you can enforce 2 factor
@@ -90,8 +92,6 @@ the [concourse website](http://concourse.ci/teams.html).
 
  * [`concourse_auth_username`]: String(optional): Basic authentication username
  * [`concourse_auth_password`]: String(optional): Basic authentication password
- * [`concourse_prometheus_bind_ip`]: String(optional) default 0.0.0.0: IP to listen on to expose Prometheus metrics 
- * [`concourse_prometheus_bind_port`]: String(optional) default 9391: Port to listen on to expose Prometheus metrics 
 
 ### Output
  * [`elb_dns_name`]: String: DNS name of the loadbalancer

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ the [concourse website](http://concourse.ci/teams.html).
 
  * [`concourse_auth_username`]: String(optional): Basic authentication username
  * [`concourse_auth_password`]: String(optional): Basic authentication password
+ * [`concourse_prometheus_bind_ip`]: String(optional) default 0.0.0.0: IP to listen on to expose Prometheus metrics 
+ * [`concourse_prometheus_bind_port`]: String(optional) default 9391: Port to listen on to expose Prometheus metrics 
 
 ### Output
  * [`elb_dns_name`]: String: DNS name of the loadbalancer
@@ -120,6 +122,8 @@ module "concourse-web" {
   keys_bucket_arn                     = "${module.keys.keys_bucket_arn}"
   vault_server_url                    = "https://vault.example.com"
   vault_auth_concourse_role_name      = "${module.concourse-vault-auth.concourse_vault_role_name}"
+  concourse_prometheus_bind_ip        = "0.0.0.0"
+  concourse_prometheus_bind_port      = "9391"
 }
 ```
 

--- a/ecs-web/elb.tf
+++ b/ecs-web/elb.tf
@@ -49,3 +49,23 @@ resource "aws_security_group_rule" "sg_ecs_instances_elb_out_ssh" {
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
 }
+
+# Allow traffic to Prometheus metrics from the ECS security group
+resource "aws_security_group_rule" "sg_ecs_instances_out_metrics" {
+  security_group_id = "${var.backend_security_group_id}"
+  type              = "egress"
+  from_port         = "${var.concourse_prometheus_bind_port}"
+  to_port           = "${var.concourse_prometheus_bind_port}"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+# Allow Prometheus metrics from to ECS on ECS security group
+resource "aws_security_group_rule" "sg_ecs_instances_in_metrics" {
+  security_group_id = "${var.backend_security_group_id}"
+  type              = "ingress"
+  from_port         = "${var.concourse_prometheus_bind_port}"
+  to_port           = "${var.concourse_prometheus_bind_port}"
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}

--- a/ecs-web/elb.tf
+++ b/ecs-web/elb.tf
@@ -68,4 +68,5 @@ resource "aws_security_group_rule" "sg_ecs_instances_in_metrics" {
   to_port           = "${var.concourse_prometheus_bind_port}"
   protocol          = "tcp"
   cidr_blocks       = ["0.0.0.0/0"]
+  source_security_group_id = "${module.elb.sg_id}"
 }

--- a/ecs-web/elb.tf
+++ b/ecs-web/elb.tf
@@ -60,7 +60,7 @@ resource "aws_security_group_rule" "sg_ecs_instances_out_metrics" {
   cidr_blocks       = ["0.0.0.0/0"]
 }
 
-# Allow Prometheus metrics from to ECS on ECS security group
+# Allow trrafic from Prometheus metrics to the ECS security group
 resource "aws_security_group_rule" "sg_ecs_instances_in_metrics" {
   security_group_id = "${var.backend_security_group_id}"
   type              = "ingress"

--- a/ecs-web/elb.tf
+++ b/ecs-web/elb.tf
@@ -67,6 +67,5 @@ resource "aws_security_group_rule" "sg_ecs_instances_in_metrics" {
   from_port         = "${var.concourse_prometheus_bind_port}"
   to_port           = "${var.concourse_prometheus_bind_port}"
   protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  source_security_group_id = "${module.elb.sg_id}"
+  self              = true
 }

--- a/ecs-web/main.tf
+++ b/ecs-web/main.tf
@@ -30,17 +30,19 @@ data "template_file" "concourse_web_task_template" {
   template = "${file("${path.module}/task-definitions/concourse_web_service.json")}"
 
   vars {
-    image                      = "${var.concourse_docker_image}:${var.concourse_version}"
-    concourse_hostname         = "${var.concourse_hostname}"
-    concourse_db_uri           = "postgres://${var.concourse_db_username}:${var.concourse_db_password}@${var.concourse_db_host}:${var.concourse_db_port}/${var.concourse_db_name}"
-    awslog_group_name          = "${aws_cloudwatch_log_group.concourse_web_log_group.name}"
-    awslog_region              = "${data.aws_region.current.name}"
-    concourse_keys_bucket_name = "${var.keys_bucket_id}"
-    concourse_basic_auth       = "${length(var.concourse_auth_username) > 0 && length(var.concourse_auth_password) > 0 ? data.template_file.concourse_basic_auth.rendered : ""}"
-    concourse_github_auth      = "${length(var.concourse_github_auth_client_id) > 0 && length(var.concourse_github_auth_client_secret) > 0 && length(var.concourse_github_auth_team) > 0 ? data.template_file.concourse_github_auth.rendered : ""}"
-    concourse_vault_variables  = "${length(var.vault_server_url) > 0 ? data.template_file.concourse_vault_variables.rendered : ""}"
-    memory                     = "${var.container_memory}"
-    cpu                        = "${var.container_cpu}"
+    image                          = "${var.concourse_docker_image}:${var.concourse_version}"
+    concourse_hostname             = "${var.concourse_hostname}"
+    concourse_db_uri               = "postgres://${var.concourse_db_username}:${var.concourse_db_password}@${var.concourse_db_host}:${var.concourse_db_port}/${var.concourse_db_name}"
+    awslog_group_name              = "${aws_cloudwatch_log_group.concourse_web_log_group.name}"
+    awslog_region                  = "${data.aws_region.current.name}"
+    concourse_keys_bucket_name     = "${var.keys_bucket_id}"
+    concourse_basic_auth           = "${length(var.concourse_auth_username) > 0 && length(var.concourse_auth_password) > 0 ? data.template_file.concourse_basic_auth.rendered : ""}"
+    concourse_github_auth          = "${length(var.concourse_github_auth_client_id) > 0 && length(var.concourse_github_auth_client_secret) > 0 && length(var.concourse_github_auth_team) > 0 ? data.template_file.concourse_github_auth.rendered : ""}"
+    concourse_vault_variables      = "${length(var.vault_server_url) > 0 ? data.template_file.concourse_vault_variables.rendered : ""}"
+    memory                         = "${var.container_memory}"
+    cpu                            = "${var.container_cpu}"
+    concourse_prometheus_bind_ip   = "${var.concourse_prometheus_bind_ip}"
+    concourse_prometheus_bind_port = "${var.concourse_prometheus_bind_port}"
   }
 }
 

--- a/ecs-web/task-definitions/concourse_web_service.json
+++ b/ecs-web/task-definitions/concourse_web_service.json
@@ -24,7 +24,7 @@
       ${concourse_vault_variables}
       { "name": "_CONCOURSE_KEYS_S3"              , "value": "s3://${concourse_keys_bucket_name}/"  },
       { "name": "CONCOURSE_PROMETHEUS_BIND_IP"  , "value": "${concourse_prometheus_bind_ip}"        },
-      { "name": "CONCOURSE_PROMETHEUS_BIND_PORT"  , "value": "${concourse_prometheus_bind_port}"        }
+      { "name": "CONCOURSE_PROMETHEUS_BIND_PORT"  , "value": "${concourse_prometheus_bind_port}"    }
 
     ],
     "logConfiguration": {

--- a/ecs-web/task-definitions/concourse_web_service.json
+++ b/ecs-web/task-definitions/concourse_web_service.json
@@ -19,10 +19,13 @@
     "environment": [
       ${concourse_basic_auth}
       ${concourse_github_auth}
-      { "name": "CONCOURSE_EXTERNAL_URL"          , "value": "https://${concourse_hostname}"            },
+      { "name": "CONCOURSE_EXTERNAL_URL"          , "value": "https://${concourse_hostname}"        },
       { "name": "CONCOURSE_POSTGRES_DATA_SOURCE"  , "value": "${concourse_db_uri}"                  },
       ${concourse_vault_variables}
-      { "name": "_CONCOURSE_KEYS_S3"              , "value": "s3://${concourse_keys_bucket_name}/"  }
+      { "name": "_CONCOURSE_KEYS_S3"              , "value": "s3://${concourse_keys_bucket_name}/"  },
+      { "name": "CONCOURSE_PROMETHEUS_BIND_IP"  , "value": "${concourse_prometheus_bind_ip}"        },
+      { "name": "CONCOURSE_PROMETHEUS_BIND_PORT"  , "value": "${concourse_prometheus_bind_port}"        }
+
     ],
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/ecs-web/variables.tf
+++ b/ecs-web/variables.tf
@@ -129,3 +129,14 @@ variable "container_memory" {
 variable "container_cpu" {
   default = 256
 }
+
+variable "concourse_prometheus_bind_ip" {
+  description = "IP to listen on to expose Prometheus metrics"
+  default = "0.0.0.0"
+}
+
+variable "concourse_prometheus_bind_port" {
+  description = "Port to listen on to expose Prometheus metrics"
+  default = "9391"
+}
+

--- a/ecs-web/variables.tf
+++ b/ecs-web/variables.tf
@@ -132,11 +132,10 @@ variable "container_cpu" {
 
 variable "concourse_prometheus_bind_ip" {
   description = "IP to listen on to expose Prometheus metrics"
-  default = "0.0.0.0"
+  default     = "0.0.0.0"
 }
 
 variable "concourse_prometheus_bind_port" {
   description = "Port to listen on to expose Prometheus metrics"
-  default = "9391"
+  default     = "9391"
 }
-


### PR DESCRIPTION
Expose metrics for Prometheus on `0.0.0.0:9391` and allow traffic to and from it 

Related issue: https://github.com/skyscrapers/engineering/issues/25