### PR TITLE
Add launchconfig for ephemeral storage instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,11 @@ The following resources will be created:
 | teleport_sg | Teleport server security group id | string | `` | no |
 | teleport_version | teleport version for the client | string | `2.5.8` | no |
 | vpc_id | The VPC id where to deploy the worker instances | string | - | yes |
-| work_disk_device_name | Device name of the external EBS volume | string | `/dev/xvdf` | no |
-| work_disk_internal_device_name | Device name of the internal volume | string | `/dev/xvdf` | no |
-| work_disk_volume_size | Size of the external EBS volume | string | `100` | no |
-| work_disk_volume_type | Volume type of the external EBS volume | string | `standard` | no |
+| work_disk_ephemeral | Whether to use ephemeral volumes as Concourse worker storage. You must use an `instance_type` that supports this (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames) | bool | false | no
+| work_disk_device_name | Device name of the external EBS volume to use as Concourse worker storage | string | `/dev/xvdf` | no |
+| work_disk_internal_device_name | Device name of the internal volume as identified by the Linux kernel, which can differ from `work_disk_device_name` depending on used AMI. Make sure this is set according the `instance_type`, eg. `/dev/nvme0n1` when using NVMe ephemeral storage | string | `/dev/xvdf` | no |
+| work_disk_volume_size | Size of the external EBS volume to use as Concourse worker storage | string | `100` | no |
+| work_disk_volume_type | Volume type of the external EBS volume to use as Concourse worker storage | string | `standard` | no |
 | worker_tsa_port | tsa port that the worker can use to connect to the web | string | `2222` | no |
 
 ### Output

--- a/ec2-worker/asg.tf
+++ b/ec2-worker/asg.tf
@@ -21,6 +21,7 @@ module "is_ebs_optimised" {
 }
 
 resource "aws_launch_configuration" "concourse_worker_launchconfig" {
+  count                = "${var.work_disk_ephemeral ? 0 : 1}"
   image_id             = "${length(var.custom_ami) == 0 ? data.aws_ami.ubuntu.id : var.custom_ami}"
   instance_type        = "${var.instance_type}"
   key_name             = "${var.ssh_key_name}"
@@ -48,9 +49,36 @@ resource "aws_launch_configuration" "concourse_worker_launchconfig" {
   }
 }
 
+resource "aws_launch_configuration" "concourse_worker_launchconfig_ephemeral" {
+  count                = "${var.work_disk_ephemeral ? 1 : 0}"
+  image_id             = "${length(var.custom_ami) == 0 ? data.aws_ami.ubuntu.id : var.custom_ami}"
+  instance_type        = "${var.instance_type}"
+  key_name             = "${var.ssh_key_name}"
+  security_groups      = ["${concat(list(aws_security_group.worker_instances_sg.id), var.additional_security_group_ids)}"]
+  iam_instance_profile = "${aws_iam_instance_profile.concourse_worker_instance_profile.id}"
+  user_data            = "${data.template_cloudinit_config.concourse_bootstrap.rendered}"
+  ebs_optimized        = "${module.is_ebs_optimised.is_ebs_optimised}"
+
+  root_block_device {
+    volume_type           = "${var.root_disk_volume_type}"
+    volume_size           = "${var.root_disk_volume_size}"
+    delete_on_termination = "true"
+  }
+
+  # This is the work dir for concourse
+  ephemeral_block_device {
+    device_name  = "${var.work_disk_internal_device_name}"
+    virtual_name = "ephemeral0"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_autoscaling_group" "concourse_worker_asg" {
   name                 = "concourse_worker_${var.environment}_${var.name}_asg"
-  launch_configuration = "${aws_launch_configuration.concourse_worker_launchconfig.id}"
+  launch_configuration = "${element(concat(aws_launch_configuration.concourse_worker_launchconfig.*.id, aws_launch_configuration.concourse_worker_launchconfig_ephemeral.*.id), 0)}"
   vpc_zone_identifier  = ["${var.subnet_ids}"]
   max_size             = "${var.concourse_worker_instance_count}"
   min_size             = "${var.concourse_worker_instance_count}"
@@ -94,6 +122,14 @@ data "template_file" "concourse_bootstrap" {
   }
 }
 
+data "template_file" "check_attachment" {
+  template = "${file("${path.module}/check_attachment.sh.tpl")}"
+
+  vars {
+    work_disk_device_name = "${var.work_disk_device_name}"
+  }
+}
+
 data "template_cloudinit_config" "concourse_bootstrap" {
   gzip          = true
   base64_encode = true
@@ -122,11 +158,7 @@ EOF
   # And format and mount the drive
   part {
     content_type = "text/x-shellscript"
-
-    content = <<EOF
-#!/bin/bash
-aws --region $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//') ec2 wait volume-in-use --filters Name=attachment.instance-id,Values=$(curl -s http://169.254.169.254/latest/meta-data/instance-id) Name=attachment.device,Values=${var.work_disk_device_name}
-EOF
+    content      = "${var.work_disk_ephemeral ? "" : data.template_file.check_attachment.rendered}"
   }
 
   # Format external volume as btrfs

--- a/ec2-worker/check_attachment.sh.tpl
+++ b/ec2-worker/check_attachment.sh.tpl
@@ -1,0 +1,3 @@
+#!/bin/bash
+aws --region $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/[a-z]$//') ec2 wait volume-in-use --filters Name=attachment.instance-id,Values=$(curl -s http://169.254.169.254/latest/meta-data/instance-id) Name=attachment.device,Values=${work_disk_device_name}
+EOF}"

--- a/ec2-worker/variables.tf
+++ b/ec2-worker/variables.tf
@@ -49,23 +49,28 @@ variable "root_disk_volume_size" {
   default     = "10"
 }
 
+variable "work_disk_ephemeral" {
+  description = "Whether to use ephemeral volumes as Concourse worker storage. You must use an `instance_type` that supports this (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames)"
+  default     = false
+}
+
 variable "work_disk_device_name" {
-  description = "Device name of the external EBS volume"
+  description = "Device name of the external EBS volume to use as Concourse worker storage"
   default     = "/dev/xvdf"
 }
 
 variable "work_disk_internal_device_name" {
-  description = "Device name of the internal volume"
+  description = "Device name of the internal volume as identified by the Linux kernel, which can differ from `work_disk_device_name` depending on used AMI. Make sure this is set according the `instance_type`, eg. `/dev/nvme0n1` when using NVMe ephemeral storage"
   default     = "/dev/xvdf"
 }
 
 variable "work_disk_volume_type" {
-  description = "Volume type of the external EBS volume"
+  description = "Volume type of the external EBS volume to use as Concourse worker storage"
   default     = "standard"
 }
 
 variable "work_disk_volume_size" {
-  description = "Size of the external EBS volume"
+  description = "Size of the external EBS volume to use as Concourse worker storage"
   default     = "100"
 }
 


### PR DESCRIPTION
Allows the usage of instances with ephemeral storage (like `m5d` and `c5d` types) for Concourse workers. 

Since TF doesn't support proper conditionals (yet), we have to create an extra launchconfig and switch between them depending on the `work_disk_ephemeral` variable.

Related issue: https://github.com/skyscrapers/qover/issues/31

Not tested yet, but these are the plans:

Without ephemeral storage:
```
Terraform will perform the following actions:

  ~ module.concourse-worker.aws_autoscaling_group.concourse_worker_asg
      launch_configuration:                              "terraform-20180808083324463000000001" => "${element(concat(aws_launch_configuration.concourse_worker_launchconfig.*.id, aws_launch_configuration.concourse_worker_launchconfig_ephemeral
.*.id), 0)}"

-/+ module.concourse-worker.aws_launch_configuration.concourse_worker_launchconfig (new resource required)
      id:                                                "terraform-20180808083324463000000001" => <computed> (forces new resource)
      associate_public_ip_address:                       "false" => "false"
      ebs_block_device.#:                                "1" => "1"
      ebs_block_device.2642828297.delete_on_termination: "true" => "true"
      ebs_block_device.2642828297.device_name:           "/dev/xvdf" => "/dev/xvdf"
      ebs_block_device.2642828297.encrypted:             "false" => <computed>
      ebs_block_device.2642828297.iops:                  "0" => <computed>
      ebs_block_device.2642828297.no_device:             "false" => ""
      ebs_block_device.2642828297.snapshot_id:           "" => <computed>
      ebs_block_device.2642828297.volume_size:           "100" => "100"
      ebs_block_device.2642828297.volume_type:           "gp2" => "gp2"
      ebs_optimized:                                     "true" => "true"
      enable_monitoring:                                 "true" => "true"
      iam_instance_profile:                              "concourse_worker_tools_instance_profile" => "concourse_worker_tools_instance_profile"
      image_id:                                          "ami-0a8458313ef39d6f6" => "ami-0181f8d9b6f098ec4" (forces new resource)
      instance_type:                                     "m5.large" => "m5.large"
      key_name:                                          "skyscrapers" => "skyscrapers"
      name:                                              "terraform-20180808083324463000000001" => <computed>
      root_block_device.#:                               "1" => "1"
      root_block_device.0.delete_on_termination:         "true" => "true"
      root_block_device.0.iops:                          "0" => <computed>
      root_block_device.0.volume_size:                   "10" => "10"
      root_block_device.0.volume_type:                   "standard" => "standard"
      security_groups.#:                                 "2" => "2"
      security_groups.3908446097:                        "sg-d761d7aa" => "sg-d761d7aa"
      security_groups.4278728360:                        "sg-4fe5ac35" => "sg-4fe5ac35"
      user_data:                                         "bd875828bb1e9e5e12d5204a075a14de2ef3f8c4" => "78fb6377be157e859ca5b76846edc8cc7f16659a" (forces new resource)


Plan: 1 to add, 1 to change, 1 to destroy.
```

With ephemeral storage:
```
Terraform will perform the following actions:

  ~ module.concourse-worker.aws_autoscaling_group.concourse_worker_asg
      launch_configuration:                         "terraform-20180808083324463000000001" => "${element(concat(aws_launch_configuration.concourse_worker_launchconfig.*.id, aws_launch_configuration.concourse_worker_launchconfig_ephemeral.*.id), 0)}"

  - module.concourse-worker.aws_launch_configuration.concourse_worker_launchconfig

  + module.concourse-worker.aws_launch_configuration.concourse_worker_launchconfig_ephemeral
      id:                                           <computed>
      associate_public_ip_address:                  "false"
      ebs_block_device.#:                           <computed>
      ebs_optimized:                                "false"
      enable_monitoring:                            "true"
      ephemeral_block_device.#:                     "1"
      ephemeral_block_device.74644781.device_name:  "/dev/nvme0n1"
      ephemeral_block_device.74644781.virtual_name: "ephemeral0"
      iam_instance_profile:                         "concourse_worker_tools_instance_profile"
      image_id:                                     "ami-0181f8d9b6f098ec4"
      instance_type:                                "c5d.large"
      key_name:                                     "skyscrapers"
      name:                                         <computed>
      root_block_device.#:                          "1"
      root_block_device.0.delete_on_termination:    "true"
      root_block_device.0.iops:                     <computed>
      root_block_device.0.volume_size:              "10"
      root_block_device.0.volume_type:              "standard"
      security_groups.#:                            "2"
      security_groups.3908446097:                   "sg-d761d7aa"
      security_groups.4278728360:                   "sg-4fe5ac35"
      user_data:                                    "57fad6ea8e82dfafe06d75ae2c80ff1880b0ef5f"


Plan: 1 to add, 1 to change, 1 to destroy.
```