### PR TITLE
Increase the NOFILE limit for the concourse worker process

### DIFF
--- a/ec2-worker/concourse_systemd.tpl
+++ b/ec2-worker/concourse_systemd.tpl
@@ -13,5 +13,7 @@ Group=root
 
 Type=simple
 
+LimitNOFILE=20000
+
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
We've seen a couple of times that a worker would just crash after it runs out of file descriptors. This increases the limit to a reasonable value.