### PR TITLE
Increase nofile limit for the web container and add log filter metrics for Concourse errors

### DIFF
--- a/ecs-web/main.tf
+++ b/ecs-web/main.tf
@@ -96,3 +96,29 @@ resource "aws_cloudwatch_log_group" "concourse_web_log_group" {
     Project     = "concourse"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "atc_errors" {
+  name           = "ConcourseATCErrors"
+  pattern        = "{ $.log_level > 1 && $.source = atc }"
+  log_group_name = "${aws_cloudwatch_log_group.concourse_web_log_group.name}"
+
+  metric_transformation {
+    name          = "ConcourseATCErrors"
+    namespace     = "LogMetrics"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "tsa_errors" {
+  name           = "ConcourseTSAErrors"
+  pattern        = "{ $.log_level > 1 && $.source = tsa }"
+  log_group_name = "${aws_cloudwatch_log_group.concourse_web_log_group.name}"
+
+  metric_transformation {
+    name          = "ConcourseTSAErrors"
+    namespace     = "LogMetrics"
+    value         = "1"
+    default_value = "0"
+  }
+}

--- a/ecs-web/task-definitions/concourse_web_service.json
+++ b/ecs-web/task-definitions/concourse_web_service.json
@@ -16,6 +16,13 @@
         "hostPort": 2222
       }
     ],
+    "ulimits": [
+      {
+        "softLimit": 20000,
+        "hardLimit": 20000,
+        "name": "nofile"
+      }
+    ],
     "environment": [
       ${concourse_basic_auth}
       ${concourse_github_auth}


### PR DESCRIPTION
There are two changes in this PR:

- It increases the `nofile` ulimit of the Concourse web container to 20000
- It adds a couple of log filters in CloudWatch to monitor the error occurrences in the Concourse logs (one for the ATC and another for the TSA)