### PR TITLE
Add support for concourse v4

### DIFF
--- a/ecs-web/main.tf
+++ b/ecs-web/main.tf
@@ -48,8 +48,6 @@ data "template_file" "concourse_web_task_template" {
   }
 }
 
-
-
 data "template_file" "concourse_vault_variables" {
   template = <<EOF
 { "name": "CONCOURSE_VAULT_URL", "value": "$${concourse_vault_url}" },

--- a/ecs-web/main.tf
+++ b/ecs-web/main.tf
@@ -32,7 +32,11 @@ data "template_file" "concourse_web_task_template" {
   vars {
     image                      = "${var.concourse_docker_image}:${var.concourse_version}"
     concourse_hostname         = "${var.concourse_hostname}"
-    concourse_db_uri           = "postgres://${var.concourse_db_username}:${var.concourse_db_password}@${var.concourse_db_host}:${var.concourse_db_port}/${var.concourse_db_name}"
+    concourse_db_host          = "${var.concourse_db_host}"
+    concourse_db_port          = "${var.concourse_db_port}"
+    concourse_db_user          = "${var.concourse_db_username}"
+    concourse_db_password      = "${var.concourse_db_password}"
+    concourse_db_name          = "${var.concourse_db_name}"
     awslog_group_name          = "${aws_cloudwatch_log_group.concourse_web_log_group.name}"
     awslog_region              = "${data.aws_region.current.name}"
     concourse_keys_bucket_name = "${var.keys_bucket_id}"
@@ -43,6 +47,8 @@ data "template_file" "concourse_web_task_template" {
     cpu                        = "${var.container_cpu}"
   }
 }
+
+
 
 data "template_file" "concourse_vault_variables" {
   template = <<EOF
@@ -62,8 +68,8 @@ EOF
 
 data "template_file" "concourse_basic_auth" {
   template = <<EOF
-{ "name": "CONCOURSE_BASIC_AUTH_USERNAME", "value": "$${concourse_auth_username}" },
-{ "name": "CONCOURSE_BASIC_AUTH_PASSWORD", "value": "$${concourse_auth_password}" },
+{ "name": "CONCOURSE_ADD_LOCAL_USER", "value": "$${concourse_auth_username}:$${concourse_auth_password}" },
+{ "name": "CONCOURSE_MAIN_TEAM_LOCAL_USER", "value": "$${concourse_auth_username}" },
 EOF
 
   vars {
@@ -74,9 +80,9 @@ EOF
 
 data "template_file" "concourse_github_auth" {
   template = <<EOF
-{ "name": "CONCOURSE_GITHUB_AUTH_CLIENT_ID", "value": "$${concourse_github_auth_client_id}" },
-{ "name": "CONCOURSE_GITHUB_AUTH_CLIENT_SECRET", "value": "$${concourse_github_auth_client_secret}" },
-{ "name": "CONCOURSE_GITHUB_AUTH_TEAM", "value": "$${concourse_github_auth_team}" },
+{ "name": "CONCOURSE_GITHUB_CLIENT_ID", "value": "$${concourse_github_auth_client_id}" },
+{ "name": "CONCOURSE_GITHUB_CLIENT_SECRET", "value": "$${concourse_github_auth_client_secret}" },
+{ "name": "CONCOURSE_MAIN_TEAM_GITHUB_TEAM", "value": "$${concourse_github_auth_team}" },
 EOF
 
   vars {

--- a/ecs-web/main.tf
+++ b/ecs-web/main.tf
@@ -67,7 +67,6 @@ EOF
 data "template_file" "concourse_basic_auth" {
   template = <<EOF
 { "name": "CONCOURSE_ADD_LOCAL_USER", "value": "$${concourse_auth_username}:$${concourse_auth_password}" },
-{ "name": "CONCOURSE_MAIN_TEAM_LOCAL_USER", "value": "$${concourse_auth_username}" },
 EOF
 
   vars {

--- a/ecs-web/task-definitions/concourse_web_service.json
+++ b/ecs-web/task-definitions/concourse_web_service.json
@@ -1,41 +1,46 @@
 [
   {
-    "name": "concourse_web",
-    "image": "${image}",
-    "command": [ "web" ],
-    "cpu": ${cpu},
-    "memory": ${memory},
-    "essential": true,
+    "name"        : "concourse_web",
+    "image"       : "${image}",
+    "command"     : [ "web" ],
+    "cpu"         : ${cpu},
+    "memory"      : ${memory},
+    "essential"   : true,
     "portMappings": [
       {
         "containerPort": 8080,
-        "hostPort": 8080
+        "hostPort"     : 8080
       },
       {
         "containerPort": 2222,
-        "hostPort": 2222
+        "hostPort"     : 2222
       }
     ],
     "ulimits": [
       {
         "softLimit": 20000,
         "hardLimit": 20000,
-        "name": "nofile"
+        "name"     : "nofile"
       }
     ],
     "environment": [
       ${concourse_basic_auth}
       ${concourse_github_auth}
-      { "name": "CONCOURSE_EXTERNAL_URL"          , "value": "https://${concourse_hostname}"            },
-      { "name": "CONCOURSE_POSTGRES_DATA_SOURCE"  , "value": "${concourse_db_uri}"                  },
+      { "name": "CONCOURSE_EXTERNAL_URL"      , "value": "https://${concourse_hostname}" },
+      { "name": "CONCOURSE_POSTGRES_HOST"     , "value": "${concourse_db_host}" },
+      { "name": "CONCOURSE_POSTGRES_PORT"     , "value": "${concourse_db_port}" },
+      { "name": "CONCOURSE_POSTGRES_USER"     , "value": "${concourse_db_user}" },
+      { "name": "CONCOURSE_POSTGRES_PASSWORD" , "value": "${concourse_db_password}" },
+      { "name": "CONCOURSE_POSTGRES_DATABASE" , "value": "${concourse_db_name}" },
+      
       ${concourse_vault_variables}
-      { "name": "_CONCOURSE_KEYS_S3"              , "value": "s3://${concourse_keys_bucket_name}/"  }
+      { "name": "_CONCOURSE_KEYS_S3"          , "value": "s3://${concourse_keys_bucket_name}/"  }
     ],
     "logConfiguration": {
       "logDriver": "awslogs",
-      "options": {
-        "awslogs-group": "${awslog_group_name}",
-        "awslogs-region": "${awslog_region}",
+      "options"  : {
+        "awslogs-group"        : "${awslog_group_name}",
+        "awslogs-region"       : "${awslog_region}",
         "awslogs-stream-prefix": "concourse_web"
       }
     },


### PR DESCRIPTION
If applied this makes the terraform module compatibe with v4 of concourse and adresses the following points:
- PostgreSQL connection string is deprecated
The postgres-data-source flag is deprecated. Therefore we migrated this away to the new separate parameters to set the database connection. This doesn't break anything nor does it require changes in the documentation or usage of the module

- concourse authentication
Local users (user&password authentication) must be created at boot time in the concourse web container, and then granted access in each team with fly set-team command. See [Configuring Auth Providers](https://concourse-ci.org/install.html#auth-config) for more info.
This functionality was also already here but the names of the environment variables are changed.

https://github.com/skyscrapers/engineering/issues/113