### PR TITLE
Configure the concourse vault role to issue periodic tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ This module sets up the needed Vault resources for Concourse:
 | vault_aws_auth_backend_path | The path the AWS auth backend being configured was mounted at | string | `aws` | no |
 | vault_concourse_role_name | Name to give to the Vault role and policy for Concourse | string | - | yes |
 | vault_server_url | The Vault server url | string | - | yes |
-| vault_token_period | Vault token renewal period, in seconds. This make the token to never expire, but still has to be renewed within the duration specified by this value | string | `43200` | no |
+| vault_token_period | Vault token renewal period, in seconds. This sets the token to never expire, but it still has to be renewed within the duration specified by this value | string | `43200` | no |
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -209,11 +209,12 @@ This module sets up the needed Vault resources for Concourse:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| additional_vault_policies | Additional Vault policies to attach to the Concourse role. Defaults to empty list | string | `<list>` | no |
-| concourse_iam_role_arn | IAM role ARN of the Concourse ATC server | string | - | yes |
-| vault_aws_auth_backend_path | The path the AWS auth backend being configured was mounted at. Defaults to aws. | string | `aws` | no |
+| additional_vault_policies | Additional Vault policies to attach to the Concourse role | string | `<list>` | no |
+| concourse_iam_role_arn | IAM role ARN of the Concourse ATC server. You can get this from the concourse web module outputs | string | - | yes |
+| vault_aws_auth_backend_path | The path the AWS auth backend being configured was mounted at | string | `aws` | no |
 | vault_concourse_role_name | Name to give to the Vault role and policy for Concourse | string | - | yes |
 | vault_server_url | The Vault server url | string | - | yes |
+| vault_token_period | Vault token renewal period, in seconds. This make the token to never expire, but still has to be renewed within the duration specified by this value | string | `43200` | no |
 
 ### Output
 

--- a/vault-auth/role.tf
+++ b/vault-auth/role.tf
@@ -4,4 +4,5 @@ resource "vault_aws_auth_backend_role" "concourse" {
   auth_type               = "iam"
   bound_iam_principal_arn = "${var.concourse_iam_role_arn}"
   policies                = ["${concat(list(vault_policy.concourse.name), var.additional_vault_policies)}"]
+  period                  = "${var.vault_token_period}"
 }

--- a/vault-auth/variables.tf
+++ b/vault-auth/variables.tf
@@ -21,6 +21,6 @@ variable "vault_server_url" {
 }
 
 variable "vault_token_period" {
-  description = "Vault token renewal period, in seconds. This make the token to never expire, but still has to be renewed within the duration specified by this value"
+  description = "Vault token renewal period, in seconds. This sets the token to never expire, but it still has to be renewed within the duration specified by this value"
   default     = 43200
 }

--- a/vault-auth/variables.tf
+++ b/vault-auth/variables.tf
@@ -3,19 +3,24 @@ variable "vault_concourse_role_name" {
 }
 
 variable "additional_vault_policies" {
-  description = "Additional Vault policies to attach to the Concourse role. Defaults to empty list"
+  description = "Additional Vault policies to attach to the Concourse role"
   default     = []
 }
 
 variable "concourse_iam_role_arn" {
-  description = "IAM role ARN of the Concourse ATC server"
+  description = "IAM role ARN of the Concourse ATC server. You can get this from the concourse web module outputs"
 }
 
 variable "vault_aws_auth_backend_path" {
-  description = "The path the AWS auth backend being configured was mounted at. Defaults to aws."
+  description = "The path the AWS auth backend being configured was mounted at"
   default     = "aws"
 }
 
 variable "vault_server_url" {
   description = "The Vault server url"
+}
+
+variable "vault_token_period" {
+  description = "Vault token renewal period, in seconds. This make the token to never expire, but still has to be renewed within the duration specified by this value"
+  default     = 43200
 }


### PR DESCRIPTION
Currently, concourse can't use the AWS auth method to retrieve a Vault token, so we retrieve the token before starting the `concourse web` process via the Vault cli, and then provide that token to the Concourse process.
Because of that, Concourse can't get a new token when this one expires, and the whole process has to be restarted. To avoid this, we've configured the Vault auth role to issue periodic tokens, which never expire as long as they are renewed in time (which concourse already does).

As per https://github.com/skyscrapers/engineering/issues/104