### PR TITLE
adding prometheus metrics for concourse

### DIFF
--- a/ecs-web/main.tf
+++ b/ecs-web/main.tf
@@ -13,7 +13,7 @@ resource "aws_ecs_service" "concourse_web" {
     container_port = 8080
   }
 
-  placement_strategy {
+  ordered_placement_strategy {
     type  = "spread"
     field = "instanceId"
   }
@@ -46,6 +46,8 @@ data "template_file" "concourse_web_task_template" {
     concourse_vault_variables      = "${length(var.vault_server_url) > 0 ? data.template_file.concourse_vault_variables.rendered : ""}"
     memory                         = "${var.container_memory}"
     cpu                            = "${var.container_cpu}"
+    concourse_prometheus_bind_port = "${var.concourse_prometheus_bind_port}"
+    concourse_prometheus_bind_ip   = "${var.concourse_prometheus_bind_ip}"
   }
 }
 

--- a/ecs-web/task-definitions/concourse_web_service.json
+++ b/ecs-web/task-definitions/concourse_web_service.json
@@ -14,6 +14,10 @@
       {
         "containerPort": 2222,
         "hostPort"     : 2222
+      },
+      {
+        "containerPort": ${concourse_prometheus_bind_port},
+        "hostPort"     : ${concourse_prometheus_bind_port}
       }
     ],
     "ulimits": [
@@ -33,7 +37,9 @@
       { "name": "CONCOURSE_POSTGRES_USER"     , "value": "${concourse_db_user}" },
       { "name": "CONCOURSE_POSTGRES_PASSWORD" , "value": "${concourse_db_password}" },
       { "name": "CONCOURSE_POSTGRES_DATABASE" , "value": "${concourse_db_name}" },
-      
+      { "name": "CONCOURSE_PROMETHEUS_BIND_PORT" , "value": "${concourse_prometheus_bind_port}" },
+      { "name": "CONCOURSE_PROMETHEUS_BIND_IP" , "value": "${concourse_prometheus_bind_ip}" },
+
       ${concourse_vault_variables}
       { "name": "_CONCOURSE_KEYS_S3"          , "value": "s3://${concourse_keys_bucket_name}/"  }
     ],

--- a/ecs-web/variables.tf
+++ b/ecs-web/variables.tf
@@ -134,3 +134,16 @@ variable "container_memory" {
 variable "container_cpu" {
   default = 256
 }
+
+variable "concourse_prometheus_bind_port" {
+  default = "9391"
+}
+
+variable "concourse_prometheus_bind_ip" {
+  default = "0.0.0.0"
+}
+
+variable "prometheus_cidrs" {
+  type    = "list"
+  default = []
+}


### PR DESCRIPTION
This PR allows to add the concourse metrics to the elb in order to make it available for the prometheus ecs cluster