### PR TITLE
Some fixes to make Concourse work again with normal EBS volumes

### DIFF
--- a/ec2-worker/bootstrap_concourse.sh.tpl
+++ b/ec2-worker/bootstrap_concourse.sh.tpl
@@ -3,7 +3,7 @@
 set -e
 
 # Install concourse
-curl -L -f -o /usr/local/bin/concourse https://github.com/concourse/concourse/releases/download/v${concourse_version}/concourse_linux_amd64
+curl -s -L -f -o /usr/local/bin/concourse https://github.com/concourse/concourse/releases/download/v${concourse_version}/concourse_linux_amd64
 chmod +x /usr/local/bin/concourse
 
 # AssumeRole for remote TSA

--- a/ec2-worker/iam.tf
+++ b/ec2-worker/iam.tf
@@ -1,69 +1,69 @@
-resource "aws_iam_role" "concourse_worker_role" {
-  name = "concourse_worker_${var.environment}_${var.name}_role"
+data "aws_iam_policy_document" "concourse_worker_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
     }
-  ]
+  }
 }
-EOF
+
+resource "aws_iam_role" "concourse_worker_role" {
+  name               = "concourse_worker_${var.environment}_${var.name}_role"
+  assume_role_policy = "${data.aws_iam_policy_document.concourse_worker_role.json}"
+}
+
+data "aws_iam_policy_document" "concourse_worker_policy" {
+  statement {
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    resources = [
+      "${var.keys_bucket_arn}",
+      "${var.keys_bucket_arn}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ec2:DescribeVolume*", # needed to query the status of the worker volume
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "concourse_worker_policy" {
-  count = "${length(var.cross_account_worker_role_arn) > 0 ? 0 : 1}" # Disable if accessing another AWS account through an assume role
-  name  = "concourse_worker_${var.environment}_${var.name}_policy"
-  role  = "${aws_iam_role.concourse_worker_role.id}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:Get*",
-        "s3:List*"
-      ],
-      "Resource": [
-        "${var.keys_bucket_arn}",
-        "${var.keys_bucket_arn}/*"
-      ]
-    }
-  ]
+  count  = "${length(var.cross_account_worker_role_arn) > 0 ? 0 : 1}"     # Disable if accessing another AWS account through an assume role
+  name   = "concourse_worker_${var.environment}_${var.name}_policy"
+  role   = "${aws_iam_role.concourse_worker_role.id}"
+  policy = "${data.aws_iam_policy_document.concourse_worker_policy.json}"
 }
-EOF
+
+data "aws_iam_policy_document" "concourse_worker_cross_account_policy" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    resources = [
+      "${var.cross_account_worker_role_arn}",
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "concourse_worker_cross_account_policy" {
-  count = "${length(var.cross_account_worker_role_arn) > 0 ? 1 : 0}"      # Enable if accessing another AWS account through an assume role
-  name  = "concourse_worker_cross_account_${var.environment}_${var.name}"
-  role  = "${aws_iam_role.concourse_worker_role.id}"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "sts:AssumeRole"
-      ],
-      "Resource": [
-        "${var.cross_account_worker_role_arn}"
-      ]
-    }
-  ]
-}
-EOF
+  count  = "${length(var.cross_account_worker_role_arn) > 0 ? 1 : 0}"                   # Enable if accessing another AWS account through an assume role
+  name   = "concourse_worker_cross_account_${var.environment}_${var.name}"
+  role   = "${aws_iam_role.concourse_worker_role.id}"
+  policy = "${data.aws_iam_policy_document.concourse_worker_cross_account_policy.json}"
 }
 
 resource "aws_iam_instance_profile" "concourse_worker_instance_profile" {

--- a/ec2-worker/variables.tf
+++ b/ec2-worker/variables.tf
@@ -56,12 +56,12 @@ variable "work_disk_ephemeral" {
 
 variable "work_disk_device_name" {
   description = "Device name of the external EBS volume to use as Concourse worker storage"
-  default     = "/dev/xvdf"
+  default     = "/dev/sdf"
 }
 
 variable "work_disk_internal_device_name" {
-  description = "Device name of the internal volume as identified by the Linux kernel, which can differ from `work_disk_device_name` depending on used AMI. Make sure this is set according the `instance_type`, eg. `/dev/nvme0n1` when using NVMe ephemeral storage"
-  default     = "/dev/xvdf"
+  description = "Device name of the internal volume as identified by the Linux kernel, which can differ from `work_disk_device_name` depending on used AMI. Make sure this is set according the `instance_type`, eg. `/dev/xvdf` when using an older AMI"
+  default     = "/dev/nvme1n1"
 }
 
 variable "work_disk_volume_type" {


### PR DESCRIPTION
At some point, the support for normal EBS volumes has broken,  probably due to the internal device name change. This fixes those issues.

- The worker didn't have permissions to query the EBS volume attachment and status, needed in the [cloud-init script](https://github.com/skyscrapers/terraform-concourse/blob/master/ec2-worker/check_attachment.sh.tpl#L2).
- The internal device name in recent AMIs is in nvme notation, and the default value in the module was still xvdf

Additionally:

- Made curl silent
- Switched to `aws_iam_policy_document` data sources


As per https://github.com/skyscrapers/engineering/issues/148