### PR TITLE
Small improvements in the ec2-worker module

### DIFF
--- a/ec2-worker/asg.tf
+++ b/ec2-worker/asg.tf
@@ -261,10 +261,15 @@ EOF
 }
 
 module "teleport_bootstrap_script" {
-  source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=3.2.0"
+  source      = "github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script?ref=3.3.5"
   auth_server = "${var.teleport_server}"
   auth_token  = "${var.teleport_auth_token}"
   function    = "concourse"
   environment = "${var.environment}"
   project     = "${var.project}"
+
+  additional_labels = [
+    "concourse_version: \"${var.concourse_version}\"",
+    "instance_type: \"${var.instance_type}\"",
+  ]
 }

--- a/ec2-worker/concourse_systemd.tpl
+++ b/ec2-worker/concourse_systemd.tpl
@@ -3,7 +3,6 @@ Description=Concourse CI Worker
 
 [Service]
 ExecStart=/usr/local/bin/concourse worker \
-       --ephemeral \
        --work-dir /opt/concourse \
        --tsa-host ${concourse_hostname} \
        --tsa-public-key /etc/concourse/tsa_host_key.pub \

--- a/ec2-worker/concourse_systemd.tpl
+++ b/ec2-worker/concourse_systemd.tpl
@@ -3,6 +3,7 @@ Description=Concourse CI Worker
 
 [Service]
 ExecStart=/usr/local/bin/concourse worker \
+       --ephemeral \
        --work-dir /opt/concourse \
        --tsa-host ${concourse_hostname} \
        --tsa-public-key /etc/concourse/tsa_host_key.pub \


### PR DESCRIPTION
~- Make concourse workers ephemeral.~ _Removed [as agreed](https://github.com/skyscrapers/terraform-concourse/pull/41#issuecomment-441180292)_
  > With the `--ephemeral` flag, the worker will be immediately removed upon stalling.
- Add some additional labels for concourse workers in teleport