### PR TITLE
Small fixes in preparation for the automated tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Compiled files
 *.tfstate
-*.tfstate.backup
+*.tfstate.*
 
 # Module directory
 .terraform/
 terraform.tfstate.d
+
+vendor

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The following resources are created:
 | concourse_github_auth_client_id | Github client id | string | `` | no |
 | concourse_github_auth_client_secret | Github client secret | string | `` | no |
 | concourse_github_auth_team | Github team that can login | string | `` | no |
-| concourse_hostname | Hostname on what concourse will be available, this hostname needs to point to the ELB. If ommitted, the hostname of the AWS ELB will be used instead | string | `` | no |
+| concourse_hostname | Hostname on which concourse will be available, this hostname needs to point to the ELB. If ommitted, the hostname of the AWS ELB will be used instead | string | `` | no |
 | concourse_prometheus_bind_ip | IP address where Concourse will listen for the Prometheus scraper | string | `0.0.0.0` | no |
 | concourse_prometheus_bind_port | Port where Concourse will listen for the Prometheus scraper | string | `9391` | no |
 | concourse_vault_auth_backend_max_ttl | The Vault max-ttl (in seconds) that Concourse will use | string | `2592000` | no |

--- a/ec2-worker/asg.tf
+++ b/ec2-worker/asg.tf
@@ -33,7 +33,8 @@ resource "aws_launch_template" "concourse_worker_launchtemplate" {
   }
 
   network_interfaces {
-    security_groups = ["${concat(list(aws_security_group.worker_instances_sg.id), var.additional_security_group_ids)}"]
+    security_groups       = ["${concat(list(aws_security_group.worker_instances_sg.id), var.additional_security_group_ids)}"]
+    delete_on_termination = true
   }
 
   iam_instance_profile {

--- a/ec2-worker/variables.tf
+++ b/ec2-worker/variables.tf
@@ -50,7 +50,7 @@ variable "root_disk_volume_size" {
 }
 
 variable "work_disk_ephemeral" {
-  description = "Whether to use ephemeral volumes as Concourse worker storage. You must use an `instance_type` that supports this (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames)"
+  description = "Whether to use ephemeral volumes as Concourse worker storage. You must use an [`instance_type` that supports this](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames)"
   default     = false
 }
 

--- a/ecs-web/elb.tf
+++ b/ecs-web/elb.tf
@@ -76,10 +76,11 @@ resource "aws_security_group_rule" "sg_ecs_instances_elb_out_prometheus" {
 }
 
 resource "aws_security_group_rule" "sg_elb_in_prometheus" {
+  count             = "${length(var.prometheus_cidrs) > 0 ? 1 : 0}"
   security_group_id = "${module.elb.sg_id}"
   type              = "ingress"
   from_port         = "${var.concourse_prometheus_bind_port}"
   to_port           = "${var.concourse_prometheus_bind_port}"
   protocol          = "tcp"
-  cidr_blocks       = ["${var.prometheus_cidrs}"]
+  cidr_blocks       = "${var.prometheus_cidrs}"
 }

--- a/ecs-web/main.tf
+++ b/ecs-web/main.tf
@@ -26,12 +26,16 @@ resource "aws_ecs_task_definition" "concourse_web_task_definition" {
   task_role_arn         = "${aws_iam_role.concourse_task_role.arn}"
 }
 
+locals {
+  concourse_hostname = "${var.concourse_hostname == "" ? module.elb.elb_dns_name : var.concourse_hostname}"
+}
+
 data "template_file" "concourse_web_task_template" {
   template = "${file("${path.module}/task-definitions/concourse_web_service.json")}"
 
   vars {
     image                          = "${var.concourse_docker_image}:${var.concourse_version}"
-    concourse_hostname             = "${var.concourse_hostname}"
+    concourse_hostname             = "${local.concourse_hostname}"
     concourse_db_host              = "${var.concourse_db_host}"
     concourse_db_port              = "${var.concourse_db_port}"
     concourse_db_user              = "${var.concourse_db_username}"
@@ -80,7 +84,7 @@ EOF
 
 data "template_file" "concourse_basic_auth_main_team_local_user" {
   template = <<EOF
-{ "name": "CONCOURSE_MAIN_TEAM_LOCAL_USERS", "value": "$${concourse_auth_username}" },
+{ "name": "CONCOURSE_MAIN_TEAM_LOCAL_USER", "value": "$${concourse_auth_username}" },
 EOF
 
   vars {

--- a/ecs-web/outputs.tf
+++ b/ecs-web/outputs.tf
@@ -1,15 +1,24 @@
 output "elb_dns_name" {
-  value = "${module.elb.elb_dns_name}"
+  description = "DNS name of the loadbalancer"
+  value       = "${module.elb.elb_dns_name}"
 }
 
 output "elb_zone_id" {
-  value = "${module.elb.elb_zone_id}"
+  description = "Zone ID of the ELB"
+  value       = "${module.elb.elb_zone_id}"
 }
 
 output "elb_sg_id" {
-  value = "${module.elb.sg_id}"
+  description = "Security group id of the loadbalancer"
+  value       = "${module.elb.sg_id}"
+}
+
+output "concourse_hostname" {
+  description = "Final Concourse hostname"
+  value       = "${local.concourse_hostname}"
 }
 
 output "iam_role_arn" {
-  value = "${aws_iam_role.concourse_task_role.arn}"
+  description = "ARN of the IAM role created for the Concourse ECS task"
+  value       = "${aws_iam_role.concourse_task_role.arn}"
 }

--- a/ecs-web/variables.tf
+++ b/ecs-web/variables.tf
@@ -7,15 +7,16 @@ variable "name" {
 }
 
 variable "ecs_cluster" {
-  description = "name of the ecs cluster"
+  description = "Name of the ecs cluster"
 }
 
 variable "concourse_hostname" {
-  description = " hostname on what concourse will be available, this hostname needs to point to the ELB."
+  description = "Hostname on what concourse will be available, this hostname needs to point to the ELB. If ommitted, the hostname of the AWS ELB will be used instead"
+  default     = ""
 }
 
 variable "concourse_docker_image" {
-  description = "docker image to use to start concourse"
+  description = "Docker image to use to start concourse"
   default     = "skyscrapers/concourse"
 }
 
@@ -25,25 +26,25 @@ variable "concourse_version" {
 }
 
 variable "concourse_db_host" {
-  description = "postgresql hostname or IP"
+  description = "Postgresql server hostname or IP"
 }
 
 variable "concourse_db_port" {
-  description = "port of the postgresql server"
+  description = "Port of the postgresql server"
   default     = "5432"
 }
 
 variable "concourse_db_username" {
-  description = "db user to logon to postgresql"
+  description = "Database user to logon to postgresql"
   default     = "concourse"
 }
 
 variable "concourse_db_password" {
-  description = "password to logon to postgresql"
+  description = "Password to logon to postgresql"
 }
 
 variable "concourse_db_name" {
-  description = "db name to use on the postgresql server"
+  description = "Database name to use on the postgresql server"
   default     = "concourse"
 }
 
@@ -92,7 +93,7 @@ variable "elb_subnets" {
 }
 
 variable "backend_security_group_id" {
-  description = ""
+  description = "Security group ID of the ECS servers"
 }
 
 variable "ssl_certificate_id" {
@@ -114,36 +115,42 @@ variable "keys_bucket_arn" {
 }
 
 variable "vault_server_url" {
-  description = "The Vault server URL to configure in Concourse. Leaving it empty will disable the Vault integration."
+  description = "The Vault server URL to configure in Concourse. Leaving it empty will disable the Vault integration"
   default     = ""
 }
 
 variable "vault_auth_concourse_role_name" {
-  description = "The Vault role that Concourse will use. This is normally fetched from the `vault-auth` terraform module."
+  description = "The Vault role that Concourse will use. This is normally fetched from the `vault-auth` Terraform module"
   default     = ""
 }
 
 variable "concourse_vault_auth_backend_max_ttl" {
-  default = "2592000"
+  description = "The Vault max-ttl (in seconds) that Concourse will use"
+  default     = "2592000"
 }
 
 variable "container_memory" {
-  default = 256
+  description = "The amount of memory (in MiB) used by the task"
+  default     = 256
 }
 
 variable "container_cpu" {
-  default = 256
+  description = "The number of cpu units to reserve for the container. This parameter maps to CpuShares in the Create a container section of the Docker Remote API"
+  default     = 256
 }
 
 variable "concourse_prometheus_bind_port" {
-  default = "9391"
+  description = "Port where Concourse will listen for the Prometheus scraper"
+  default     = "9391"
 }
 
 variable "concourse_prometheus_bind_ip" {
-  default = "0.0.0.0"
+  description = "IP address where Concourse will listen for the Prometheus scraper"
+  default     = "0.0.0.0"
 }
 
 variable "prometheus_cidrs" {
-  type    = "list"
-  default = []
+  description = "CIDR blocks that'll allowed to access the Prometheus scraper port"
+  type        = "list"
+  default     = []
 }

--- a/ecs-web/variables.tf
+++ b/ecs-web/variables.tf
@@ -11,7 +11,7 @@ variable "ecs_cluster" {
 }
 
 variable "concourse_hostname" {
-  description = "Hostname on what concourse will be available, this hostname needs to point to the ELB. If ommitted, the hostname of the AWS ELB will be used instead"
+  description = "Hostname on which concourse will be available, this hostname needs to point to the ELB. If ommitted, the hostname of the AWS ELB will be used instead"
   default     = ""
 }
 

--- a/keys/s3.tf
+++ b/keys/s3.tf
@@ -1,6 +1,7 @@
 resource "aws_s3_bucket" "concourse_keys" {
-  bucket = "concourse-keys-${var.name}-${var.environment}"
-  acl    = "private"
+  bucket        = "concourse-keys-${var.name}-${var.environment}"
+  acl           = "private"
+  force_destroy = "${var.bucket_force_destroy}"
 
   versioning {
     enabled = true

--- a/keys/variables.tf
+++ b/keys/variables.tf
@@ -20,3 +20,8 @@ variable "concourse_workers_iam_role_arns" {
   type        = "list"
   description = "List of ARNs for the IAM roles that will be able to assume the role to access concourse keys in S3. Normally you'll include the Concourse worker IAM role here"
 }
+
+variable "bucket_force_destroy" {
+  description = "A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable"
+  default     = false
+}


### PR DESCRIPTION
As per https://github.com/skyscrapers/engineering/issues/149

* Documentation fixes and added descriptions to some variables and outputs that were missing them
* Added option to force the deletion for the Keys S3 bucket. Useful to tear down the test setup
* Added `delete_on_termination` option in the workers network interface attachment. Without this option those network interfaces are left there when the worker instances get terminated
* Make `prometheus_cidrs` variable optional
* Make `concourse_hostname` variable optional. If omitted, the hostname of the ELB will be used
* Fix `CONCOURSE_MAIN_TEAM_LOCAL_USER` env variable name