### PR TITLE
Lock Vault version instead of using latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The following resources are created:
 | prometheus_cidrs | CIDR blocks that'll allowed to access the Prometheus scraper port | list | `<list>` | no |
 | ssl_certificate_id | SSL certificate arn to attach to the ELB | string | - | yes |
 | vault_auth_concourse_role_name | The Vault role that Concourse will use. This is normally fetched from the `vault-auth` Terraform module | string | `` | no |
-| vault_docker_image_tag | Docker image version to use for the Vault auth container | string | `latest` | no |
+| vault_docker_image_tag | Docker image version to use for the Vault auth container | string | `1.1.3` | no |
 | vault_server_url | The Vault server URL to configure in Concourse. Leaving it empty will disable the Vault integration | string | `` | no |
 | concourse\_extra\_args | Extra arguments to pass to Concourse Web | string | `null` | no |
 | concourse\_extra\_env | Extra ENV variables to pass to Concourse Web. Use a map with the ENV var name as key and value as value | map(string) | `null` | no |

--- a/ecs-web/variables.tf
+++ b/ecs-web/variables.tf
@@ -205,7 +205,7 @@ variable "prometheus_cidrs" {
 
 variable "vault_docker_image_tag" {
   description = "Docker image version to use for the Vault auth container"
-  default     = "latest"
+  default     = "1.1.3"
   type        = string
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Lock the Vault image version to the latest we've tested.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
/

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`latest` is currently giving aws auth issues for us.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
