### PR TITLE
Allow assigning public IPs to workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,37 +134,37 @@ The following resources will be created:
 ### Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| concourse\_hostname | Hostname on what concourse will be available, this hostname needs to point to the ELB. | string | n/a | yes |
-| environment | The name of the environment these subnets belong to \(prod,stag,dev\) | string | n/a | yes |
-| instance\_type | EC2 instance type for the worker instances | string | n/a | yes |
-| keys\_bucket\_arn | The S3 bucket ARN which contains the SSH keys to connect to the TSA | string | n/a | yes |
-| keys\_bucket\_id | The S3 bucket id which contains the SSH keys to connect to the TSA | string | n/a | yes |
-| name | A descriptive name of the purpose of this Concourse worker pool | string | n/a | yes |
-| ssh\_key\_name | The key name to use for the instance | string | n/a | yes |
-| subnet\_ids | List of subnet ids where to deploy the worker instances | list(string) | n/a | yes |
-| vpc\_id | The VPC id where to deploy the worker instances | string | n/a | yes |
-| additional\_security\_group\_ids | Additional security group ids to attach to the worker instances | list(string) | `[]` | no |
-| concourse\_tags | List of tags to add to the worker to use for assigning jobs and tasks | list(string) | `[]` | no |
-| concourse\_version | Concourse CI version to use. Defaults to the latest tested version | string | `"5.7.2"` | no |
-| concourse\_version\_override | Variable to override the default Concourse version. Leave it empty to fallback to `concourse\_version`. Useful if you want to default to the module's default but also give the users the option to override it | string | `"null"` | no |
-| concourse\_worker\_instance\_count | Number of Concourse worker instances | number | `"1"` | no |
-| cpu\_credits | The credit option for CPU usage. Can be `standard` or `unlimited` | string | `"standard"` | no |
-| cross\_account\_worker\_role\_arn | IAM role ARN to assume to access the Concourse keys bucket in another AWS account | string | `"null"` | no |
-| custom\_ami | Use a custom AMI for the worker instances. If omitted the latest Ubuntu 16.04 AMI will be used. | string | `"null"` | no |
-| project | Project where the concourse claster belongs to. This is mainly used to identify it in Teleport | string | `""` | no |
-| public | Whether to assign these worker nodes a public IP \(when public subnets are defined in `var.subnet\_ids`\) | bool | `"false"` | no |
-| root\_disk\_volume\_size | Size of the worker instances root disk | string | `"10"` | no |
-| root\_disk\_volume\_type | Volume type of the worker instances root disk | string | `"gp2"` | no |
-| teleport\_auth\_token | Teleport node token to authenticate with the auth server | string | `""` | no |
-| teleport\_server | Teleport auth server hostname | string | `""` | no |
-| teleport\_version | Teleport version for the client | string | `"4.1.1"` | no |
-| work\_disk\_device\_name | Device name of the external EBS volume to use as Concourse worker storage | string | `"/dev/sdf"` | no |
-| work\_disk\_ephemeral | Whether to use ephemeral volumes as Concourse worker storage. You must use an \[`instance\_type` that supports this\]\(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames\) | string | `"false"` | no |
-| work\_disk\_internal\_device\_name | Device name of the internal volume as identified by the Linux kernel, which can differ from `work\_disk\_device\_name` depending on used AMI. Make sure this is set according the `instance\_type`, eg. `/dev/xvdf` when using an older AMI | string | `"/dev/nvme1n1"` | no |
-| work\_disk\_volume\_size | Size of the external EBS volume to use as Concourse worker storage | string | `"100"` | no |
-| work\_disk\_volume\_type | Volume type of the external EBS volume to use as Concourse worker storage | string | `"gp2"` | no |
-| worker\_tsa\_port | tsa port that the worker can use to connect to the web | string | `"2222"` | no |
+|------|-------------|------|---------|:-----:|
+| concourse\_hostname | Hostname on what concourse will be available, this hostname needs to point to the ELB. | `string` | n/a | yes |
+| concourse\_version\_override | Variable to override the default Concourse version. Leave it empty to fallback to `concourse_version`. Useful if you want to default to the module's default but also give the users the option to override it | `string` | n/a | yes |
+| cross\_account\_worker\_role\_arn | IAM role ARN to assume to access the Concourse keys bucket in another AWS account | `string` | n/a | yes |
+| custom\_ami | Use a custom AMI for the worker instances. If omitted the latest Ubuntu 16.04 AMI will be used. | `string` | n/a | yes |
+| environment | The name of the environment these subnets belong to (prod,stag,dev) | `string` | n/a | yes |
+| instance\_type | EC2 instance type for the worker instances | `string` | n/a | yes |
+| keys\_bucket\_arn | The S3 bucket ARN which contains the SSH keys to connect to the TSA | `string` | n/a | yes |
+| keys\_bucket\_id | The S3 bucket id which contains the SSH keys to connect to the TSA | `string` | n/a | yes |
+| name | A descriptive name of the purpose of this Concourse worker pool | `string` | n/a | yes |
+| ssh\_key\_name | The key name to use for the instance | `string` | n/a | yes |
+| subnet\_ids | List of subnet ids where to deploy the worker instances | `list(string)` | n/a | yes |
+| vpc\_id | The VPC id where to deploy the worker instances | `string` | n/a | yes |
+| additional\_security\_group\_ids | Additional security group ids to attach to the worker instances | `list(string)` | `[]` | no |
+| concourse\_tags | List of tags to add to the worker to use for assigning jobs and tasks | `list(string)` | `[]` | no |
+| concourse\_version | Concourse CI version to use. Defaults to the latest tested version | `string` | `"5.7.2"` | no |
+| concourse\_worker\_instance\_count | Number of Concourse worker instances | `number` | `1` | no |
+| cpu\_credits | The credit option for CPU usage. Can be `standard` or `unlimited` | `string` | `"standard"` | no |
+| project | Project where the concourse claster belongs to. This is mainly used to identify it in Teleport | `string` | `""` | no |
+| public | Whether to assign these worker nodes a public IP (when public subnets are defined in `var.subnet_ids`) | `bool` | `false` | no |
+| root\_disk\_volume\_size | Size of the worker instances root disk | `string` | `"10"` | no |
+| root\_disk\_volume\_type | Volume type of the worker instances root disk | `string` | `"gp2"` | no |
+| teleport\_auth\_token | Teleport node token to authenticate with the auth server | `string` | `""` | no |
+| teleport\_server | Teleport auth server hostname | `string` | `""` | no |
+| teleport\_version | Teleport version for the client | `string` | `"4.1.1"` | no |
+| work\_disk\_device\_name | Device name of the external EBS volume to use as Concourse worker storage | `string` | `"/dev/sdf"` | no |
+| work\_disk\_ephemeral | Whether to use ephemeral volumes as Concourse worker storage. You must use an [`instance_type` that supports this](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames) | `string` | `false` | no |
+| work\_disk\_internal\_device\_name | Device name of the internal volume as identified by the Linux kernel, which can differ from `work_disk_device_name` depending on used AMI. Make sure this is set according the `instance_type`, eg. `/dev/xvdf` when using an older AMI | `string` | `"/dev/nvme1n1"` | no |
+| work\_disk\_volume\_size | Size of the external EBS volume to use as Concourse worker storage | `string` | `"100"` | no |
+| work\_disk\_volume\_type | Volume type of the external EBS volume to use as Concourse worker storage | `string` | `"gp2"` | no |
+| worker\_tsa\_port | tsa port that the worker can use to connect to the web | `string` | `"2222"` | no |
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -131,51 +131,52 @@ The following resources will be created:
 * Security group
 * IAM role
 
-### Available variables
+### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| additional_security_group_ids | Additional security group ids to attach to the worker instances | list | `<list>` | no |
-| concourse_hostname | Hostname on what concourse will be available, this hostname needs to point to the ELB. | string | - | yes |
-| concourse_tags | List of tags to add to the worker to use for assigning jobs and tasks | list | `<list>` | no |
-| concourse_version | Concourse CI version to use. Defaults to the latest tested version | string | `"5.2.0"` | no |
-| concourse_version_override | Variable to override the default Concourse version. Leave it empty to fallback to `concourse_version`. Useful if you want to default to the module's default but also give the users the option to override it | string | `` | no |
-| concourse_worker_instance_count | Number of Concourse worker instances | string | `1` | no |
-| cpu_credits | The credit option for CPU usage. Can be `standard` or `unlimited` | string | `standard` | no |
-| cross_account_worker_role_arn | IAM role ARN to assume to access the Concourse keys bucket in another AWS account | string | `` | no |
-| custom_ami | Use a custom AMI for the worker instances. If omitted the latest Ubuntu 16.04 AMI will be used. | string | `` | no |
-| environment | The name of the environment these subnets belong to (prod,stag,dev) | string | - | yes |
-| instance_type | EC2 instance type for the worker instances | string | - | yes |
-| keys_bucket_arn | The S3 bucket ARN which contains the SSH keys to connect to the TSA | string | - | yes |
-| keys_bucket_id | The S3 bucket id which contains the SSH keys to connect to the TSA | string | - | yes |
-| name | A descriptive name of the purpose of this Concourse worker pool | string | - | yes |
-| project | Project where the concourse claster belongs to. This is mainly used to identify it in Teleport | string | `` | no |
-| root_disk_volume_size | Size of the worker instances root disk | string | `10` | no |
-| root_disk_volume_type | Volume type of the worker instances root disk | string | `gp2` | no |
-| ssh_key_name | The key name to use for the instance | string | - | yes |
-| subnet_ids | List of subnet ids where to deploy the worker instances | list | - | yes |
-| teleport_auth_token | Teleport node token to authenticate with the auth server | string | `` | no |
-| teleport_server | Teleport auth server hostname | string | `` | no |
-| teleport_version | Teleport version for the client | string | `4.1.1` | no |
-| vpc_id | The VPC id where to deploy the worker instances | string | - | yes |
-| work_disk_device_name | Device name of the external EBS volume to use as Concourse worker storage | string | `/dev/sdf` | no |
-| work_disk_ephemeral | Whether to use ephemeral volumes as Concourse worker storage. You must use an [`instance_type` that supports this](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames) | string | `false` | no |
-| work_disk_internal_device_name | Device name of the internal volume as identified by the Linux kernel, which can differ from `work_disk_device_name` depending on used AMI. Make sure this is set according the `instance_type`, eg. `/dev/xvdf` when using an older AMI | string | `/dev/nvme1n1` | no |
-| work_disk_volume_size | Size of the external EBS volume to use as Concourse worker storage | string | `100` | no |
-| work_disk_volume_type | Volume type of the external EBS volume to use as Concourse worker storage | string | `gp2` | no |
-| worker_tsa_port | tsa port that the worker can use to connect to the web | string | `2222` | no |
+| concourse\_hostname | Hostname on what concourse will be available, this hostname needs to point to the ELB. | string | n/a | yes |
+| environment | The name of the environment these subnets belong to \(prod,stag,dev\) | string | n/a | yes |
+| instance\_type | EC2 instance type for the worker instances | string | n/a | yes |
+| keys\_bucket\_arn | The S3 bucket ARN which contains the SSH keys to connect to the TSA | string | n/a | yes |
+| keys\_bucket\_id | The S3 bucket id which contains the SSH keys to connect to the TSA | string | n/a | yes |
+| name | A descriptive name of the purpose of this Concourse worker pool | string | n/a | yes |
+| ssh\_key\_name | The key name to use for the instance | string | n/a | yes |
+| subnet\_ids | List of subnet ids where to deploy the worker instances | list(string) | n/a | yes |
+| vpc\_id | The VPC id where to deploy the worker instances | string | n/a | yes |
+| additional\_security\_group\_ids | Additional security group ids to attach to the worker instances | list(string) | `[]` | no |
+| concourse\_tags | List of tags to add to the worker to use for assigning jobs and tasks | list(string) | `[]` | no |
+| concourse\_version | Concourse CI version to use. Defaults to the latest tested version | string | `"5.7.2"` | no |
+| concourse\_version\_override | Variable to override the default Concourse version. Leave it empty to fallback to `concourse\_version`. Useful if you want to default to the module's default but also give the users the option to override it | string | `"null"` | no |
+| concourse\_worker\_instance\_count | Number of Concourse worker instances | number | `"1"` | no |
+| cpu\_credits | The credit option for CPU usage. Can be `standard` or `unlimited` | string | `"standard"` | no |
+| cross\_account\_worker\_role\_arn | IAM role ARN to assume to access the Concourse keys bucket in another AWS account | string | `"null"` | no |
+| custom\_ami | Use a custom AMI for the worker instances. If omitted the latest Ubuntu 16.04 AMI will be used. | string | `"null"` | no |
+| project | Project where the concourse claster belongs to. This is mainly used to identify it in Teleport | string | `""` | no |
+| public | Whether to assign these worker nodes a public IP \(when public subnets are defined in `var.subnet\_ids`\) | bool | `"false"` | no |
+| root\_disk\_volume\_size | Size of the worker instances root disk | string | `"10"` | no |
+| root\_disk\_volume\_type | Volume type of the worker instances root disk | string | `"gp2"` | no |
+| teleport\_auth\_token | Teleport node token to authenticate with the auth server | string | `""` | no |
+| teleport\_server | Teleport auth server hostname | string | `""` | no |
+| teleport\_version | Teleport version for the client | string | `"4.1.1"` | no |
+| work\_disk\_device\_name | Device name of the external EBS volume to use as Concourse worker storage | string | `"/dev/sdf"` | no |
+| work\_disk\_ephemeral | Whether to use ephemeral volumes as Concourse worker storage. You must use an \[`instance\_type` that supports this\]\(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames\) | string | `"false"` | no |
+| work\_disk\_internal\_device\_name | Device name of the internal volume as identified by the Linux kernel, which can differ from `work\_disk\_device\_name` depending on used AMI. Make sure this is set according the `instance\_type`, eg. `/dev/xvdf` when using an older AMI | string | `"/dev/nvme1n1"` | no |
+| work\_disk\_volume\_size | Size of the external EBS volume to use as Concourse worker storage | string | `"100"` | no |
+| work\_disk\_volume\_type | Volume type of the external EBS volume to use as Concourse worker storage | string | `"gp2"` | no |
+| worker\_tsa\_port | tsa port that the worker can use to connect to the web | string | `"2222"` | no |
 
-### Output
+### Outputs
 
 | Name | Description |
 |------|-------------|
-| concourse_version | Concourse version deployed |
-| worker_autoscaling_group_arn | The AWS region configured in the provider |
-| worker_autoscaling_group_id | The Concourse workers autoscaling group ARN |
-| worker_autoscaling_group_name | The Concourse workers autoscaling group name |
-| worker_iam_role | Role name of the worker instances |
-| worker_iam_role_arn | Role ARN of the worker instances |
-| worker_instances_sg_id | Security group ID used for the worker instances |
+| concourse\_version | Concourse version deployed |
+| worker\_autoscaling\_group\_arn | The AWS region configured in the provider |
+| worker\_autoscaling\_group\_id | The Concourse workers autoscaling group ARN |
+| worker\_autoscaling\_group\_name | The Concourse workers autoscaling group name |
+| worker\_iam\_role | Role name of the worker instances |
+| worker\_iam\_role\_arn | Role ARN of the worker instances |
+| worker\_instances\_sg\_id | Security group ID used for the worker instances |
 
 ### NOTE on the external EBS volume
 

--- a/ec2-worker/asg.tf
+++ b/ec2-worker/asg.tf
@@ -33,8 +33,9 @@ resource "aws_launch_template" "concourse_worker_launchtemplate" {
   }
 
   network_interfaces {
-    security_groups       = concat([aws_security_group.worker_instances_sg.id], var.additional_security_group_ids)
-    delete_on_termination = true
+    security_groups             = concat([aws_security_group.worker_instances_sg.id], var.additional_security_group_ids)
+    delete_on_termination       = true
+    associate_public_ip_address = var.public
   }
 
   iam_instance_profile {
@@ -80,8 +81,9 @@ resource "aws_launch_template" "concourse_worker_launchtemplate_ephemeral" {
   }
 
   network_interfaces {
-    security_groups       = concat([aws_security_group.worker_instances_sg.id], var.additional_security_group_ids)
-    delete_on_termination = true
+    security_groups             = concat([aws_security_group.worker_instances_sg.id], var.additional_security_group_ids)
+    delete_on_termination       = true
+    associate_public_ip_address = var.public
   }
 
   iam_instance_profile {

--- a/ec2-worker/variables.tf
+++ b/ec2-worker/variables.tf
@@ -162,3 +162,9 @@ variable "cpu_credits" {
   default     = "standard"
   type        = string
 }
+
+variable "public" {
+  type        = bool
+  description = "Whether to assign these worker nodes a public IP (when public subnets are defined in `var.subnet_ids`)"
+  default     = false
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Introduces the `public` variable to assign the Concourse EC2 workers a public IP, so traffic gets properly roiuted through the IGW when deployed in public subnets.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
As per skyscrapers/engineering#287

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some customers experience very high NAT GW data processed costs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
