### PR TITLE
Allow specifying the bagageclaim driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,52 +132,96 @@ The following resources will be created:
 * Security group
 * IAM role
 
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | ~> 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws) | ~> 3.74 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider_aws) | ~> 3.74 |
+| <a name="provider_template"></a> [template](#provider_template) | n/a |
+
+### Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_is_ebs_optimised"></a> [is_ebs_optimised](#module_is_ebs_optimised) | github.com/skyscrapers/terraform-instances//is_ebs_optimised | 3.1.0 |
+| <a name="module_teleport_bootstrap_script"></a> [teleport_bootstrap_script](#module_teleport_bootstrap_script) | github.com/skyscrapers/terraform-teleport//teleport-bootstrap-script | 7.2.1 |
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [aws_autoscaling_group.concourse_worker_asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_iam_instance_profile.concourse_worker_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.concourse_worker_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.concourse_worker_cross_account_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.concourse_worker_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_launch_template.concourse_worker_launchtemplate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_launch_template.concourse_worker_launchtemplate_ephemeral](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_security_group.worker_instances_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.worker_instances_to_tsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_ami.AL2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_iam_policy_document.concourse_worker_cross_account_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.concourse_worker_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.concourse_worker_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [template_cloudinit_config.concourse_bootstrap](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config) | data source |
+| [template_file.check_attachment](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+| [template_file.concourse_bootstrap](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+| [template_file.concourse_systemd](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
+
 ### Inputs
 
-| Name                            | Description                                                                                                                                                                                                                             | Type           | Default          | Required |
-| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ---------------- | :------: |
-| concourse_hostname              | Hostname on what concourse will be available, this hostname needs to point to the ELB.                                                                                                                                                  | `string`       | n/a              |   yes    |
-| environment                     | The name of the environment these subnets belong to (prod,stag,dev)                                                                                                                                                                     | `string`       | n/a              |   yes    |
-| instance_type                   | EC2 instance type for the worker instances                                                                                                                                                                                              | `string`       | n/a              |   yes    |
-| keys_bucket_arn                 | The S3 bucket ARN which contains the SSH keys to connect to the TSA                                                                                                                                                                     | `string`       | n/a              |   yes    |
-| keys_bucket_id                  | The S3 bucket id which contains the SSH keys to connect to the TSA                                                                                                                                                                      | `string`       | n/a              |   yes    |
-| name                            | A descriptive name of the purpose of this Concourse worker pool                                                                                                                                                                         | `string`       | n/a              |   yes    |
-| ssh_key_name                    | The key name to use for the instance                                                                                                                                                                                                    | `string`       | n/a              |   yes    |
-| subnet_ids                      | List of subnet ids where to deploy the worker instances                                                                                                                                                                                 | `list(string)` | n/a              |   yes    |
-| vpc_id                          | The VPC id where to deploy the worker instances                                                                                                                                                                                         | `string`       | n/a              |   yes    |
-| additional_security_group_ids   | Additional security group ids to attach to the worker instances                                                                                                                                                                         | `list(string)` | `[]`             |    no    |
-| concourse_tags                  | List of tags to add to the worker to use for assigning jobs and tasks                                                                                                                                                                   | `list(string)` | `[]`             |    no    |
-| concourse_version               | Concourse CI version to use. Defaults to the latest tested version                                                                                                                                                                      | `string`       | `"7.7.1"`        |    no    |
-| concourse_version_override      | Variable to override the default Concourse version. Leave it empty to fallback to `concourse_version`. Useful if you want to default to the module's default but also give the users the option to override it                          | `string`       | `null`           |    no    |
-| concourse_worker_instance_count | Number of Concourse worker instances                                                                                                                                                                                                    | `number`       | `1`              |    no    |
-| cpu_credits                     | The credit option for CPU usage. Can be `standard` or `unlimited`                                                                                                                                                                       | `string`       | `"standard"`     |    no    |
-| cross_account_worker_role_arn   | IAM role ARN to assume to access the Concourse keys bucket in another AWS account                                                                                                                                                       | `string`       | `null`           |    no    |
-| custom_ami                      | Use a custom AMI for the worker instances. If omitted the latest Ubuntu 16.04 AMI will be used.                                                                                                                                         | `string`       | `null`           |    no    |
-| project                         | Project where the concourse claster belongs to. This is mainly used to identify it in Teleport                                                                                                                                          | `string`       | `""`             |    no    |
-| public                          | Whether to assign these worker nodes a public IP (when public subnets are defined in `var.subnet_ids`)                                                                                                                                  | `bool`         | `false`          |    no    |
-| root_disk_volume_size           | Size of the worker instances root disk                                                                                                                                                                                                  | `string`       | `"10"`           |    no    |
-| root_disk_volume_type           | Volume type of the worker instances root disk                                                                                                                                                                                           | `string`       | `"gp2"`          |    no    |
-| teleport_auth_token             | Teleport node token to authenticate with the auth server                                                                                                                                                                                | `string`       | `""`             |    no    |
-| teleport_server                 | Teleport auth server hostname                                                                                                                                                                                                           | `string`       | `""`             |    no    |
-| teleport_version                | Teleport version for the client                                                                                                                                                                                                         | `string`       | `"4.2.10"`       |    no    |
-| work_disk_device_name           | Device name of the external EBS volume to use as Concourse worker storage                                                                                                                                                               | `string`       | `"/dev/sdf"`     |    no    |
-| work_disk_ephemeral             | Whether to use ephemeral volumes as Concourse worker storage. You must use an [`instance_type` that supports this](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames)                   | `string`       | `false`          |    no    |
-| work_disk_internal_device_name  | Device name of the internal volume as identified by the Linux kernel, which can differ from `work_disk_device_name` depending on used AMI. Make sure this is set according the `instance_type`, eg. `/dev/xvdf` when using an older AMI | `string`       | `"/dev/nvme1n1"` |    no    |
-| work_disk_volume_size           | Size of the external EBS volume to use as Concourse worker storage                                                                                                                                                                      | `string`       | `"100"`          |    no    |
-| work_disk_volume_type           | Volume type of the external EBS volume to use as Concourse worker storage                                                                                                                                                               | `string`       | `"gp2"`          |    no    |
-| worker_tsa_port                 | tsa port that the worker can use to connect to the web                                                                                                                                                                                  | `string`       | `"2222"`         |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_concourse_hostname"></a> [concourse_hostname](#input_concourse_hostname) | Hostname on what concourse will be available, this hostname needs to point to the ELB. | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input_environment) | The name of the environment these subnets belong to (prod,stag,dev) | `string` | n/a | yes |
+| <a name="input_instance_type"></a> [instance_type](#input_instance_type) | EC2 instance type for the worker instances | `string` | n/a | yes |
+| <a name="input_keys_bucket_arn"></a> [keys_bucket_arn](#input_keys_bucket_arn) | The S3 bucket ARN which contains the SSH keys to connect to the TSA | `string` | n/a | yes |
+| <a name="input_keys_bucket_id"></a> [keys_bucket_id](#input_keys_bucket_id) | The S3 bucket id which contains the SSH keys to connect to the TSA | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input_name) | A descriptive name of the purpose of this Concourse worker pool | `string` | n/a | yes |
+| <a name="input_ssh_key_name"></a> [ssh_key_name](#input_ssh_key_name) | The key name to use for the instance | `string` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet_ids](#input_subnet_ids) | List of subnet ids where to deploy the worker instances | `list(string)` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc_id](#input_vpc_id) | The VPC id where to deploy the worker instances | `string` | n/a | yes |
+| <a name="input_additional_security_group_ids"></a> [additional_security_group_ids](#input_additional_security_group_ids) | Additional security group ids to attach to the worker instances | `list(string)` | `[]` | no |
+| <a name="input_bagageclaim_driver"></a> [bagageclaim_driver](#input_bagageclaim_driver) | Which Concourse Worker bagageclaim driver to use. Supported choices: `btrfs` and `overlay` | `string` | `"overlay"` | no |
+| <a name="input_concourse_tags"></a> [concourse_tags](#input_concourse_tags) | List of tags to add to the worker to use for assigning jobs and tasks | `list(string)` | `[]` | no |
+| <a name="input_concourse_version"></a> [concourse_version](#input_concourse_version) | Concourse CI version to use. Defaults to the latest tested version | `string` | `"7.7.1"` | no |
+| <a name="input_concourse_version_override"></a> [concourse_version_override](#input_concourse_version_override) | Variable to override the default Concourse version. Leave it empty to fallback to `concourse_version`. Useful if you want to default to the module's default but also give the users the option to override it | `string` | `null` | no |
+| <a name="input_concourse_worker_instance_count"></a> [concourse_worker_instance_count](#input_concourse_worker_instance_count) | Number of Concourse worker instances | `number` | `1` | no |
+| <a name="input_cpu_credits"></a> [cpu_credits](#input_cpu_credits) | The credit option for CPU usage. Can be `standard` or `unlimited` | `string` | `"standard"` | no |
+| <a name="input_cross_account_worker_role_arn"></a> [cross_account_worker_role_arn](#input_cross_account_worker_role_arn) | IAM role ARN to assume to access the Concourse keys bucket in another AWS account | `string` | `null` | no |
+| <a name="input_custom_ami"></a> [custom_ami](#input_custom_ami) | Use a custom AMI for the worker instances. If omitted the latest Ubuntu 16.04 AMI will be used. | `string` | `null` | no |
+| <a name="input_project"></a> [project](#input_project) | Project where the concourse claster belongs to. This is mainly used to identify it in Teleport | `string` | `""` | no |
+| <a name="input_public"></a> [public](#input_public) | Whether to assign these worker nodes a public IP (when public subnets are defined in `var.subnet_ids`) | `bool` | `false` | no |
+| <a name="input_root_disk_volume_size"></a> [root_disk_volume_size](#input_root_disk_volume_size) | Size of the worker instances root disk | `string` | `"10"` | no |
+| <a name="input_root_disk_volume_type"></a> [root_disk_volume_type](#input_root_disk_volume_type) | Volume type of the worker instances root disk | `string` | `"gp2"` | no |
+| <a name="input_teleport_auth_token"></a> [teleport_auth_token](#input_teleport_auth_token) | Teleport node token to authenticate with the auth server | `string` | `""` | no |
+| <a name="input_teleport_server"></a> [teleport_server](#input_teleport_server) | Teleport auth server hostname | `string` | `""` | no |
+| <a name="input_teleport_version"></a> [teleport_version](#input_teleport_version) | Teleport version for the client | `string` | `"10.1.4"` | no |
+| <a name="input_work_disk_device_name"></a> [work_disk_device_name](#input_work_disk_device_name) | Device name of the external EBS volume to use as Concourse worker storage | `string` | `"/dev/sdf"` | no |
+| <a name="input_work_disk_ephemeral"></a> [work_disk_ephemeral](#input_work_disk_ephemeral) | Whether to use ephemeral volumes as Concourse worker storage. You must use an [`instance_type` that supports this](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames) | `string` | `false` | no |
+| <a name="input_work_disk_internal_device_name"></a> [work_disk_internal_device_name](#input_work_disk_internal_device_name) | Device name of the internal volume as identified by the Linux kernel, which can differ from `work_disk_device_name` depending on used AMI. Make sure this is set according the `instance_type`, eg. `/dev/xvdf` when using an older AMI | `string` | `"/dev/nvme1n1"` | no |
+| <a name="input_work_disk_volume_size"></a> [work_disk_volume_size](#input_work_disk_volume_size) | Size of the external EBS volume to use as Concourse worker storage | `string` | `"100"` | no |
+| <a name="input_work_disk_volume_type"></a> [work_disk_volume_type](#input_work_disk_volume_type) | Volume type of the external EBS volume to use as Concourse worker storage | `string` | `"gp2"` | no |
+| <a name="input_worker_tsa_port"></a> [worker_tsa_port](#input_worker_tsa_port) | tsa port that the worker can use to connect to the web | `string` | `"2222"` | no |
 
 ### Outputs
 
-| Name                          | Description                                     |
-| ----------------------------- | ----------------------------------------------- |
-| concourse_version             | Concourse version deployed                      |
-| worker_autoscaling_group_arn  | The AWS region configured in the provider       |
-| worker_autoscaling_group_id   | The Concourse workers autoscaling group ARN     |
-| worker_autoscaling_group_name | The Concourse workers autoscaling group name    |
-| worker_iam_role               | Role name of the worker instances               |
-| worker_iam_role_arn           | Role ARN of the worker instances                |
-| worker_instances_sg_id        | Security group ID used for the worker instances |
+| Name | Description |
+|------|-------------|
+| <a name="output_concourse_version"></a> [concourse_version](#output_concourse_version) | Concourse version deployed |
+| <a name="output_worker_autoscaling_group_arn"></a> [worker_autoscaling_group_arn](#output_worker_autoscaling_group_arn) | The AWS region configured in the provider |
+| <a name="output_worker_autoscaling_group_id"></a> [worker_autoscaling_group_id](#output_worker_autoscaling_group_id) | The Concourse workers autoscaling group ARN |
+| <a name="output_worker_autoscaling_group_name"></a> [worker_autoscaling_group_name](#output_worker_autoscaling_group_name) | The Concourse workers autoscaling group name |
+| <a name="output_worker_iam_role"></a> [worker_iam_role](#output_worker_iam_role) | Role name of the worker instances |
+| <a name="output_worker_iam_role_arn"></a> [worker_iam_role_arn](#output_worker_iam_role_arn) | Role ARN of the worker instances |
+| <a name="output_worker_instances_sg_id"></a> [worker_instances_sg_id](#output_worker_instances_sg_id) | Security group ID used for the worker instances |
 
 ### NOTE on the external EBS volume
 

--- a/ec2-worker/concourse_systemd.tpl
+++ b/ec2-worker/concourse_systemd.tpl
@@ -4,6 +4,7 @@ Description=Concourse CI Worker
 [Service]
 ExecStart=/usr/local/concourse/bin/concourse worker \
        --work-dir /opt/concourse \
+       --baggageclaim-driver ${baggageclaim_driver} \
        --tsa-host ${concourse_hostname} \
        --tsa-public-key /etc/concourse/tsa_host_key.pub \
        --tsa-worker-private-key /etc/concourse/worker_key ${tags}

--- a/ec2-worker/variables.tf
+++ b/ec2-worker/variables.tf
@@ -168,3 +168,9 @@ variable "public" {
   description = "Whether to assign these worker nodes a public IP (when public subnets are defined in `var.subnet_ids`)"
   default     = false
 }
+
+variable "bagageclaim_driver" {
+  type        = string
+  description = "Which Concourse Worker bagageclaim driver to use. Supported choices: `btrfs` and `overlay`"
+  default     = "overlay"
+}

--- a/examples/basic/concourse.tf
+++ b/examples/basic/concourse.tf
@@ -62,7 +62,7 @@ module "concourse_worker_ephemeral" {
   keys_bucket_id                  = module.concourse_keys.keys_bucket_id
   keys_bucket_arn                 = module.concourse_keys.keys_bucket_arn
   ssh_key_name                    = var.key_name
-  instance_type                   = "m5.large"
+  instance_type                   = "c5ad.large"
   subnet_ids                      = module.vpc.private_management_subnets
   vpc_id                          = module.vpc.vpc_id
   work_disk_ephemeral             = true
@@ -87,4 +87,3 @@ resource "aws_security_group_rule" "workers_ephemeral_access_out" {
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
 }
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We've been going back and forth between overlay and btrfs in the past. Concourse default is overlay, however for performance reasons we want to test with btrfs again. We seem to have more issues now with overlay than btrfs in the past too, although that's not sure yet. This change allows us to choose on the fly.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
